### PR TITLE
Improve SMS error handling and add workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ _Amul High-Protein Rose Lassi (pack of 30)_ flips from “Sold Out” ➜ “Add
    git clone https://github.com/<you>/amul-lassi-tracker.git
    cd amul-lassi-tracker
    pip install -r requirements.txt
+   ```
+
+2. **Trigger the workflow manually**
+   - Open your repository on GitHub and go to the **Actions** tab.
+   - Select **Lassi Watchdog** and use the **Run workflow** button.

--- a/check_stock.py
+++ b/check_stock.py
@@ -27,11 +27,22 @@ def send_fast2sms(msg: str):
         "Content-Type": "application/x-www-form-urlencoded",
     }
 
-    r = requests.post("https://www.fast2sms.com/dev/bulkV2",
-                      data=payload, headers=headers, timeout=10)
+    try:
+        r = requests.post(
+            "https://www.fast2sms.com/dev/bulkV2",
+            data=payload,
+            headers=headers,
+            timeout=10,
+        )
+        r.raise_for_status()
+    except requests.RequestException as e:
+        print("Fast2SMS error:", e)
+        return
+
     print("Fast2SMS:", r.status_code, r.text)
 
-def main():
+def main() -> None:
+    """Check the product page and send an SMS alert if in stock."""
     with sync_playwright() as p:
         page = p.chromium.launch(headless=True).new_page()
         page.goto(URL, timeout=60000)
@@ -48,11 +59,10 @@ def main():
         in_stock = "Add to Cart" in html and "disabled" not in html
 
         if in_stock:
-            text = urllib.parse.quote_plus(       # URL-encode just in case
-                f"🚨 Amul Rose Lassi in stock! {URL}"
-            )
             # Fast2SMS auto-decodes, so send plain (`payload` encodes)
             send_fast2sms(f"🚨 Amul Rose Lassi in stock! {URL}")
+        else:
+            print("Out of stock.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- improve error handling when sending Fast2SMS notifications
- add a short doc section on triggering the GitHub Actions workflow manually

## Testing
- `python -m py_compile check_stock.py`

------
https://chatgpt.com/codex/tasks/task_e_6844255d2458832f8366b2b1dabef13c