### PR TITLE
Adjust workflow retention

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    retention-days: 3
     steps:
       - uses: actions/checkout@v4
 
@@ -31,3 +32,4 @@ jobs:
         with:
           name: screenshots
           path: artifacts
+          retention-days: 3


### PR DESCRIPTION
## Summary
- keep workflow logs for only 3 days
- shorten uploaded artifact retention to 3 days

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68447c2de44c832f8393cdbdfcc239e3