### PR TITLE
Add UI for toggling GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ _Amul High-Protein Rose Lassi (pack of 30)_ flips from “Sold Out” ➜ “Add
 2. **Trigger the workflow manually**
    - Open your repository on GitHub and go to the **Actions** tab.
    - Select **Lassi Watchdog** and use the **Run workflow** button.
+
+## 🌐 Web UI on Vercel
+
+This repo includes a small web interface (in `web/`) that can be deployed to [Vercel](https://vercel.com). The page exposes **Enable** and **Disable** buttons that call GitHub's API to toggle the scheduled workflow.
+
+### Deploy steps
+1. Push this repository to your own GitHub account.
+2. Create a new Vercel project and import the repo.
+3. In the Vercel dashboard, define the following environment variables:
+   - `GH_REPO` – `<owner>/<repo>` name of this repo.
+   - `GH_TOKEN` – a GitHub token with `workflow` scope.
+   - `GH_WORKFLOW` – name of the workflow file (defaults to `schedule.yml`).
+4. Deploy. Visiting the deployed URL will show a page to enable or disable the workflow.

--- a/web/api/disable.js
+++ b/web/api/disable.js
@@ -1,0 +1,23 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).send('Method Not Allowed');
+    return;
+  }
+  const repo = process.env.GH_REPO;
+  const workflow = process.env.GH_WORKFLOW || 'schedule.yml';
+  const token = process.env.GH_TOKEN;
+  const url = `https://api.github.com/repos/${repo}/actions/workflows/${workflow}/disable`;
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Accept': 'application/vnd.github+json'
+    }
+  });
+  if (response.status === 204) {
+    res.status(200).send('Workflow disabled');
+  } else {
+    const text = await response.text();
+    res.status(response.status).send(text);
+  }
+}

--- a/web/api/enable.js
+++ b/web/api/enable.js
@@ -1,0 +1,23 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).send('Method Not Allowed');
+    return;
+  }
+  const repo = process.env.GH_REPO;
+  const workflow = process.env.GH_WORKFLOW || 'schedule.yml';
+  const token = process.env.GH_TOKEN;
+  const url = `https://api.github.com/repos/${repo}/actions/workflows/${workflow}/enable`;
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Accept': 'application/vnd.github+json'
+    }
+  });
+  if (response.status === 204) {
+    res.status(200).send('Workflow enabled');
+  } else {
+    const text = await response.text();
+    res.status(response.status).send(text);
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Lassi Watchdog Control</title>
+  <style>
+    body { font-family: sans-serif; max-width: 600px; margin: 40px auto; }
+    button { margin: 0 5px 10px 0; padding: 10px 20px; }
+    #result { margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <h1>Lassi Watchdog Control</h1>
+  <p>Use the buttons below to enable or disable the scheduled GitHub Action.</p>
+  <button id="enable">Enable workflow</button>
+  <button id="disable">Disable workflow</button>
+  <pre id="result"></pre>
+  <script>
+    async function call(path) {
+      document.getElementById('result').textContent = 'Processing...';
+      const res = await fetch(path, {method: 'POST'});
+      const text = await res.text();
+      document.getElementById('result').textContent = text;
+    }
+    document.getElementById('enable').onclick = () => call('/api/enable');
+    document.getElementById('disable').onclick = () => call('/api/disable');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `web` UI folder with Vercel serverless functions
- expose endpoints to enable/disable the scheduled workflow
- document Vercel deployment instructions in `README`

## Testing
- `python -m py_compile check_stock.py`
- `node -e "import('./web/api/enable.js').then(() => console.log('enable ok')).catch(e=>console.error(e))"`
- `node -e "import('./web/api/disable.js').then(() => console.log('disable ok')).catch(e=>console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_6845112dcd54832f8e7bc0622c517f33