### PR TITLE
Add status endpoint and improve web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Amul High-Protein Rose Lassi (pack of 30)_ flips from “Sold Out” ➜ “Add
 
 ## 🌐 Web UI on Vercel
 
-This repo includes a small web interface (in `web/`) that can be deployed to [Vercel](https://vercel.com). The page exposes **Enable** and **Disable** buttons that call GitHub's API to toggle the scheduled workflow.
+This repo includes a small web interface (in `web/`) that can be deployed to [Vercel](https://vercel.com). The page exposes **Enable** and **Disable** buttons and also shows the current workflow status with a **Check status** button.
 
 ### Deploy steps
 1. Push this repository to your own GitHub account.

--- a/web/api/status.js
+++ b/web/api/status.js
@@ -1,0 +1,23 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.status(405).send('Method Not Allowed');
+    return;
+  }
+  const repo = process.env.GH_REPO;
+  const workflow = process.env.GH_WORKFLOW || 'schedule.yml';
+  const token = process.env.GH_TOKEN;
+  const url = `https://api.github.com/repos/${repo}/actions/workflows/${workflow}`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Accept': 'application/vnd.github+json'
+    }
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    res.status(response.status).send(text);
+    return;
+  }
+  const data = await response.json();
+  res.status(200).json({ state: data.state });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -4,13 +4,34 @@
   <meta charset="utf-8">
   <title>Lassi Watchdog Control</title>
   <style>
-    body { font-family: sans-serif; max-width: 600px; margin: 40px auto; }
-    button { margin: 0 5px 10px 0; padding: 10px 20px; }
-    #result { margin-top: 20px; }
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 600px;
+      margin: 40px auto;
+      text-align: center;
+    }
+    button {
+      margin: 0 5px 10px 0;
+      padding: 10px 20px;
+      font-size: 16px;
+      cursor: pointer;
+    }
+    #status {
+      font-weight: bold;
+    }
+    #result {
+      margin-top: 20px;
+      white-space: pre-wrap;
+    }
   </style>
 </head>
 <body>
   <h1>Lassi Watchdog Control</h1>
+  <p>
+    Workflow status:
+    <span id="status">Loading…</span>
+    <button id="refresh">Check status</button>
+  </p>
   <p>Use the buttons below to enable or disable the scheduled GitHub Action.</p>
   <button id="enable">Enable workflow</button>
   <button id="disable">Disable workflow</button>
@@ -18,12 +39,33 @@
   <script>
     async function call(path) {
       document.getElementById('result').textContent = 'Processing...';
-      const res = await fetch(path, {method: 'POST'});
+      const res = await fetch(path, { method: 'POST' });
       const text = await res.text();
       document.getElementById('result').textContent = text;
+      await fetchStatus();
     }
+
+    async function fetchStatus() {
+      const span = document.getElementById('status');
+      span.textContent = 'Loading…';
+      try {
+        const res = await fetch('/api/status');
+        if (!res.ok) {
+          span.textContent = 'Error';
+          return;
+        }
+        const data = await res.json();
+        span.textContent = data.state;
+      } catch (e) {
+        span.textContent = 'Error';
+      }
+    }
+
     document.getElementById('enable').onclick = () => call('/api/enable');
     document.getElementById('disable').onclick = () => call('/api/disable');
+    document.getElementById('refresh').onclick = fetchStatus;
+
+    fetchStatus();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add API route to read workflow status
- show current status in UI with refresh button
- style web UI for better readability
- mention status feature in README

## Testing
- `python -m py_compile check_stock.py`
- `node -e "import('./web/api/status.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`


------
https://chatgpt.com/codex/tasks/task_e_684516c2c6fc832fa9db20d2beb572cb