### PR TITLE
Add recent GitHub runs to web

### DIFF
--- a/web/api/runs.js
+++ b/web/api/runs.js
@@ -1,0 +1,32 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.status(405).send('Method Not Allowed');
+    return;
+  }
+  const repo = process.env.GH_REPO;
+  const workflow = process.env.GH_WORKFLOW || 'schedule.yml';
+  const token = process.env.GH_TOKEN;
+  const url = `https://api.github.com/repos/${repo}/actions/workflows/${workflow}/runs?per_page=5`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Accept': 'application/vnd.github+json'
+    }
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    res.status(response.status).send(text);
+    return;
+  }
+  const data = await response.json();
+  const runs = data.workflow_runs.map(run => ({
+    id: run.id,
+    name: run.name,
+    status: run.status,
+    conclusion: run.conclusion,
+    url: run.html_url,
+    created_at: run.created_at,
+    updated_at: run.updated_at
+  }));
+  res.status(200).json({ runs });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -36,6 +36,17 @@
   <button id="enable">Enable workflow</button>
   <button id="disable">Disable workflow</button>
   <pre id="result"></pre>
+  <h2>Recent runs</h2>
+  <table id="runs" style="margin:auto; border-collapse: collapse;">
+    <thead>
+      <tr>
+        <th style="border-bottom:1px solid #ccc;padding:4px;">Time</th>
+        <th style="border-bottom:1px solid #ccc;padding:4px;">Status</th>
+        <th style="border-bottom:1px solid #ccc;padding:4px;">Details</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
   <script>
     async function call(path) {
       document.getElementById('result').textContent = 'Processing...';
@@ -63,9 +74,38 @@
 
     document.getElementById('enable').onclick = () => call('/api/enable');
     document.getElementById('disable').onclick = () => call('/api/disable');
-    document.getElementById('refresh').onclick = fetchStatus;
+    document.getElementById('refresh').onclick = () => {
+      fetchStatus();
+      fetchRuns();
+    };
+
+    async function fetchRuns() {
+      const table = document.getElementById('runs').querySelector('tbody');
+      table.innerHTML = '<tr><td colspan="3">Loading…</td></tr>';
+      try {
+        const res = await fetch('/api/runs');
+        if (!res.ok) {
+          table.innerHTML = '<tr><td colspan="3">Error</td></tr>';
+          return;
+        }
+        const data = await res.json();
+        if (!data.runs || !data.runs.length) {
+          table.innerHTML = '<tr><td colspan="3">No data</td></tr>';
+          return;
+        }
+        table.innerHTML = data.runs.map(r =>
+          `<tr>` +
+          `<td style="padding:4px;border-bottom:1px solid #eee;">${new Date(r.created_at).toLocaleString()}</td>` +
+          `<td style="padding:4px;border-bottom:1px solid #eee;">${r.conclusion || r.status}</td>` +
+          `<td style="padding:4px;border-bottom:1px solid #eee;"><a href="${r.url}" target="_blank">View</a></td>` +
+          `</tr>`).join('');
+      } catch (e) {
+        table.innerHTML = '<tr><td colspan="3">Error</td></tr>';
+      }
+    }
 
     fetchStatus();
+    fetchRuns();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show last five action runs on the web UI
- expose new `/api/runs` endpoint to query GitHub API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684526b8ad88832f9595649e4b334520