### PR TITLE
Fix: Restore artifact generation and rename project

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,4 +1,4 @@
-name: Lassi Watchdog
+name: Amul Watchdog
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The workflow definition lives in `.github/workflows/schedule.yml` and runs every
 4. **Run via GitHub Actions**
    - Fork this repository or push it to your own account.
    - Add the above variables as secrets in your GitHub project.
-   - The `Lassi Watchdog` workflow will check every two hours and upload screenshots from each run.
+   - The `Amul Watchdog` workflow will check every two hours and upload screenshots from each run.
 
 ## Optional web interface
 

--- a/scraper.py
+++ b/scraper.py
@@ -1,5 +1,5 @@
 import asyncio
-# import os # No longer needed as makedirs and screenshots are removed
+import os
 from playwright.async_api import async_playwright
 
 async def check_product_availability(url: str, pincode: str) -> tuple[bool, str]:
@@ -11,7 +11,7 @@ async def check_product_availability(url: str, pincode: str) -> tuple[bool, str]
         page = await browser.new_page()
         # await asyncio.sleep(5) # Removed sleep
 
-        # os.makedirs("artifacts", exist_ok=True) # Removed
+        os.makedirs("artifacts", exist_ok=True)
         step = 0
 
         async def log(*msgs: object) -> None:
@@ -19,12 +19,11 @@ async def check_product_availability(url: str, pincode: str) -> tuple[bool, str]
             text = " ".join(str(m) for m in msgs)
             print(text) # Keep console logging
             step += 1
-            # Screenshot logic removed
-            # safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in text)[:30]
-            # try:
-            #     await page.screenshot(path=f"artifacts/{step:02d}_{safe}.png")
-            # except Exception as e:
-            #     print(f"Error taking screenshot: {e}")
+            safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in text)[:30]
+            try:
+                await page.screenshot(path=f"artifacts/{step:02d}_{safe}.png")
+            except Exception as e:
+                print(f"Error taking screenshot: {e}")
             # await asyncio.sleep(5) # Removed sleep
 
         print(f"Navigating to {url}") # Use the url argument

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Lassi Watchdog Control</title>
+  <title>Amul Watchdog Control</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="components/style.css">
@@ -14,7 +14,7 @@
   <div class="container py-4 d-flex justify-content-center">
     <div class="card shadow-lg mx-auto">
       <div class="card-body text-center">
-        <h1 class="text-primary mb-4">Lassi Watchdog Control</h1>
+        <h1 class="text-primary mb-4">Amul Watchdog Control</h1>
         <p>
           Workflow status:
           <span id="status" class="fw-bold">Loading…</span><i data-lucide="info" class="ms-1"></i>


### PR DESCRIPTION
This commit addresses two issues:

1. Restores screenshot functionality in `scraper.py` to ensure artifacts are generated during GitHub Actions runs. This involves re-adding code to create the 'artifacts' directory and save screenshots.
2. Renames the project from "Lassi Watchdog" to "Amul Watchdog" across various files, including the GitHub Actions workflow, HTML title, and README.