### PR TITLE
Fix: Add missing python-dateutil dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4>=4.12
 playwright>=1.30
 requests>=2.32
 aiohttp>=3.0.0
+python-dateutil


### PR DESCRIPTION
The script `check_stock.py` relies on the `dateutil` library, but `python-dateutil` was not listed in `requirements.txt`. This caused a `ModuleNotFoundError` during execution.

This commit adds `python-dateutil` to `requirements.txt` to resolve the error.