### PR TITLE
Fix: Prevent settings pane from appearing dimmed

### DIFF
--- a/web/components/style.css
+++ b/web/components/style.css
@@ -767,7 +767,7 @@
 
 /* Styling for settings offcanvas so it matches the blurred card look */
 #settingsPane.offcanvas {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.85);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border-left: 1px solid rgba(209, 213, 219, 0.3);


### PR DESCRIPTION
The settings pane was appearing dimmer than intended when open due to its highly transparent background color (`rgba(255, 255, 255, 0.1)`) interacting with the Bootstrap offcanvas backdrop. The pane's `backdrop-filter` was blurring the dark backdrop, making the pane itself appear dim.

This commit changes the `background-color` of `#settingsPane.offcanvas` to `rgba(255, 255, 255, 0.85)`, making it significantly less transparent. This allows the pane to maintain its intended light, blurred appearance while still allowing the underlying UI to be dimmed by the offcanvas backdrop.