### PR TITLE
Fix: Correct snooze notification logic for product stock alerts

### DIFF
--- a/check_stock.py
+++ b/check_stock.py
@@ -173,9 +173,12 @@ async def main():
                                         notification_time_utc = datetime.now(timezone.utc)
                                         for sub_to_update in subscriptions_to_notify: # Only update those who were to be notified
                                             if sub_to_update.get('recipient_id') in subscribed_recipient_ids and sub_to_update.get('delay_on_stock'):
-                                                d_days = sub_to_update.get('delay_days', 0)
-                                                d_hours = sub_to_update.get('delay_hours', 0)
-                                                d_minutes = sub_to_update.get('delay_minutes', 0)
+                                                d_days = sub_to_update.get('delay_days')
+                                                d_days = d_days if d_days is not None else 0
+                                                d_hours = sub_to_update.get('delay_hours')
+                                                d_hours = d_hours if d_hours is not None else 0
+                                                d_minutes = sub_to_update.get('delay_minutes')
+                                                d_minutes = d_minutes if d_minutes is not None else 0
 
                                                 if d_days == 0 and d_hours == 0 and d_minutes == 0:
                                                     print(f"INFO: Subscription {sub_to_update.get('id')} for product {product_id} has zero delay_on_stock duration. No delay applied.")

--- a/web/api/subscriptions.js
+++ b/web/api/subscriptions.js
@@ -126,17 +126,34 @@ export default async function handler(req, res) {
             existingSubscription.frequency_minutes = parseInt(req.body.frequency_minutes, 10);
             updated = true;
           }
-          if (req.body.delay_days !== undefined) {
-            existingSubscription.delay_days = parseInt(req.body.delay_days, 10);
+
+          // Handle delay_days
+          const delayDays = parseInt(req.body.delay_days, 10);
+          if (req.body.delay_days !== undefined && req.body.delay_days !== null && !isNaN(delayDays)) {
+            existingSubscription.delay_days = delayDays;
+            updated = true;
+          } else if (req.body.delay_days === undefined || req.body.delay_days === null) {
+            existingSubscription.delay_days = DEFAULT_DELAY_DAYS;
             updated = true;
           }
-          if (req.body.delay_hours !== undefined) {
-            existingSubscription.delay_hours = parseInt(req.body.delay_hours, 10);
+
+          // Handle delay_hours
+          const delayHours = parseInt(req.body.delay_hours, 10);
+          if (req.body.delay_hours !== undefined && req.body.delay_hours !== null && !isNaN(delayHours)) {
+            existingSubscription.delay_hours = delayHours;
+            updated = true;
+          } else if (req.body.delay_hours === undefined || req.body.delay_hours === null) {
+            existingSubscription.delay_hours = DEFAULT_DELAY_HOURS;
             updated = true;
           }
-          if (req.body.delay_minutes !== undefined) {
-            // TODO: Add validation for 5-minute steps
-            existingSubscription.delay_minutes = parseInt(req.body.delay_minutes, 10);
+
+          // Handle delay_minutes
+          const delayMinutes = parseInt(req.body.delay_minutes, 10);
+          if (req.body.delay_minutes !== undefined && req.body.delay_minutes !== null && !isNaN(delayMinutes)) {
+            existingSubscription.delay_minutes = delayMinutes;
+            updated = true;
+          } else if (req.body.delay_minutes === undefined || req.body.delay_minutes === null) {
+            existingSubscription.delay_minutes = DEFAULT_DELAY_MINUTES;
             updated = true;
           }
 
@@ -186,9 +203,9 @@ export default async function handler(req, res) {
             frequency_hours: req.body.frequency_hours ?? DEFAULT_FREQUENCY_HOURS,
             frequency_minutes: req.body.frequency_minutes ?? DEFAULT_FREQUENCY_MINUTES, // TODO: Validate step
             delay_on_stock: delayOnStockBody !== undefined ? delayOnStockBody : false,
-            delay_days: req.body.delay_days ?? DEFAULT_DELAY_DAYS,
-            delay_hours: req.body.delay_hours ?? DEFAULT_DELAY_HOURS,
-            delay_minutes: req.body.delay_minutes ?? DEFAULT_DELAY_MINUTES, // TODO: Validate step
+            delay_days: (req.body.delay_days === undefined || req.body.delay_days === null || isNaN(parseInt(req.body.delay_days, 10))) ? DEFAULT_DELAY_DAYS : parseInt(req.body.delay_days, 10),
+            delay_hours: (req.body.delay_hours === undefined || req.body.delay_hours === null || isNaN(parseInt(req.body.delay_hours, 10))) ? DEFAULT_DELAY_HOURS : parseInt(req.body.delay_hours, 10),
+            delay_minutes: (req.body.delay_minutes === undefined || req.body.delay_minutes === null || isNaN(parseInt(req.body.delay_minutes, 10))) ? DEFAULT_DELAY_MINUTES : parseInt(req.body.delay_minutes, 10), // TODO: Validate step
             last_in_stock_at: null,
             delayed_until: null,
             last_checked_at: null, // New field for frequency logic

--- a/web/api/subscriptions.js
+++ b/web/api/subscriptions.js
@@ -128,32 +128,35 @@ export default async function handler(req, res) {
           }
 
           // Handle delay_days
-          const delayDays = parseInt(req.body.delay_days, 10);
-          if (req.body.delay_days !== undefined && req.body.delay_days !== null && !isNaN(delayDays)) {
-            existingSubscription.delay_days = delayDays;
-            updated = true;
-          } else if (req.body.delay_days === undefined || req.body.delay_days === null) {
-            existingSubscription.delay_days = DEFAULT_DELAY_DAYS;
+          if (req.body.delay_days !== undefined) {
+            const parsedValue = parseInt(req.body.delay_days, 10);
+            if (!isNaN(parsedValue)) {
+                existingSubscription.delay_days = parsedValue;
+            } else {
+                existingSubscription.delay_days = DEFAULT_DELAY_DAYS;
+            }
             updated = true;
           }
 
           // Handle delay_hours
-          const delayHours = parseInt(req.body.delay_hours, 10);
-          if (req.body.delay_hours !== undefined && req.body.delay_hours !== null && !isNaN(delayHours)) {
-            existingSubscription.delay_hours = delayHours;
-            updated = true;
-          } else if (req.body.delay_hours === undefined || req.body.delay_hours === null) {
-            existingSubscription.delay_hours = DEFAULT_DELAY_HOURS;
+          if (req.body.delay_hours !== undefined) {
+            const parsedValue = parseInt(req.body.delay_hours, 10);
+            if (!isNaN(parsedValue)) {
+                existingSubscription.delay_hours = parsedValue;
+            } else {
+                existingSubscription.delay_hours = DEFAULT_DELAY_HOURS;
+            }
             updated = true;
           }
 
           // Handle delay_minutes
-          const delayMinutes = parseInt(req.body.delay_minutes, 10);
-          if (req.body.delay_minutes !== undefined && req.body.delay_minutes !== null && !isNaN(delayMinutes)) {
-            existingSubscription.delay_minutes = delayMinutes;
-            updated = true;
-          } else if (req.body.delay_minutes === undefined || req.body.delay_minutes === null) {
-            existingSubscription.delay_minutes = DEFAULT_DELAY_MINUTES;
+          if (req.body.delay_minutes !== undefined) {
+            const parsedValue = parseInt(req.body.delay_minutes, 10);
+            if (!isNaN(parsedValue)) {
+                existingSubscription.delay_minutes = parsedValue;
+            } else {
+                existingSubscription.delay_minutes = DEFAULT_DELAY_MINUTES;
+            }
             updated = true;
           }
 

--- a/web/components/subscriptions-ui.js
+++ b/web/components/subscriptions-ui.js
@@ -682,9 +682,8 @@ async function handleSaveAllSubscriptionSettings() {
   }
 
 
-  // Optionally, refresh the modal to show the persisted state
-  if (errorCount === 0 && recipientId && modalBodyElement) {
-    // Only reload fully if no errors, to show pristine server state
+  // Always attempt to refresh the modal to show the persisted state from the server
+  if (recipientId && modalBodyElement) {
     await _loadSubscriptionsForRecipientAndRenderIntoModal(recipientId, modalBodyElement);
   }
 
@@ -693,8 +692,8 @@ async function handleSaveAllSubscriptionSettings() {
     saveBtn.disabled = false;
     saveBtn.innerHTML = originalBtnText;
   }
-  // After saving (or attempting to save), re-capture the form state and update button
-  storeInitialFormState(); // Current state becomes the new initial state
+  // After saving AND refreshing, re-capture the form state and update button
+  storeInitialFormState(); // Current state (fresh from server) becomes the new initial state
   updateSaveButtonState(); // Update button based on this new initial state
 }
 


### PR DESCRIPTION
The snooze notification setting was not working correctly due to a TypeError in `check_stock.py` when calculating the `delayed_until` timestamp. This occurred if `delay_days`, `delay_hours`, or `delay_minutes` were `None` (originating from `null` values in the KV store, which could happen if form inputs were empty).

This commit addresses the issue by:
1. Modifying the POST handler in `web/api/subscriptions.js` to ensure that `delay_days`, `delay_hours`, and `delay_minutes` are always stored as valid numbers (defaulting to component-specific defaults like 1 for days, or 0, if the input is missing or invalid), preventing `null` from being saved.
2. Confirming that the GET handler in `web/api/subscriptions.js` already correctly defaults these fields to numbers if they are `null` or `undefined` when read from KV.
3. Updating `check_stock.py` to explicitly convert any `None` values for `delay_days`, `delay_hours`, or `delay_minutes` to `0` before they are used in `timedelta` calculations, adding robustness.

These changes ensure that `delayed_until` is correctly calculated and stored, allowing the snooze functionality to work as intended.