### PR TITLE
Fix: Use Bcc for email notifications to protect recipient privacy

### DIFF
--- a/notifications.py
+++ b/notifications.py
@@ -180,12 +180,14 @@ def send_email_notification(subject: str, body: str, sender: str, recipients: li
         msg = MIMEText(body, 'html')
         msg['Subject'] = subject
         msg['From'] = sender
-        msg['To'] = ", ".join(recipients)
+        msg['To'] = sender  # Set 'To' to sender's email
+        msg['Bcc'] = ", ".join(recipients)  # Use Bcc for recipients
 
         with smtplib.SMTP(host, port) as server:
             if username and password:
                 server.starttls()  # Upgrade connection to secure
                 server.login(username, password)
+            # Send to actual recipients in Bcc, msg['To'] is just for display
             server.sendmail(sender, recipients, msg.as_string())
         print("Email notification sent successfully.")
     except smtplib.SMTPException as e:


### PR DESCRIPTION
Previously, email notifications were sent with all recipients listed in the 'To' or 'Cc' field, exposing their email addresses.

This change modifies the `send_email_notification` function in `notifications.py` to:
- Place all recipient email addresses in the 'Bcc' header.
- Set the 'To' header to the sender's email address.

This ensures that recipients' email addresses are not visible to each other, enhancing user privacy.