### PR TITLE
Add subscription timing controls and user contact FAB

### DIFF
--- a/web/components/subscription/subscription-helpers.js
+++ b/web/components/subscription/subscription-helpers.js
@@ -38,7 +38,13 @@ export function getModalFormState() {
   modalBodyElement.querySelectorAll('.list-group-item').forEach(item => {
     const checkbox = item.querySelector('.subscription-toggle');
     if (!checkbox) return;
-    formData[checkbox.dataset.productId] = { subscribed: checkbox.checked };
+    const startInput = item.querySelector('.sub-time-start');
+    const endInput = item.querySelector('.sub-time-end');
+    formData[checkbox.dataset.productId] = {
+      subscribed: checkbox.checked,
+      start: startInput ? startInput.value : '00:00',
+      end: endInput ? endInput.value : '23:59'
+    };
   });
   return JSON.stringify(formData);
 }

--- a/web/components/user-main/user.html
+++ b/web/components/user-main/user.html
@@ -17,6 +17,27 @@
     <p>More features coming soon…</p>
     <button id="logout-btn" class="btn btn-secondary mt-3">Logout</button>
   </div>
+  <button type="button" class="fab" id="feedbackFab" aria-label="Contact">
+    <i data-lucide="plus"></i>
+  </button>
+
+  <div class="modal" id="feedbackModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Get in touch</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p>Want to request a new product or send feedback? Reach out via Gmail or Reddit.</p>
+          <div class="d-flex gap-2">
+            <a href="#" id="feedbackGmail" class="btn btn-outline-primary flex-fill"><i data-lucide="mail" class="me-1"></i>Gmail</a>
+            <a href="https://www.reddit.com/message/compose/?to=ShooBum-T&subject=Feedback" target="_blank" id="feedbackReddit" class="btn btn-outline-danger flex-fill"><i data-lucide="message-circle" class="me-1"></i>Reddit</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
   <script>
     const email = localStorage.getItem("userEmail");
     if (!email) {
@@ -31,12 +52,25 @@
   </script>
   <script src="../../particles.js"></script>
   <script src="../../lucide-icons.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module">
     import { initParticles } from "../particles-config/particles-config.js";
     import { initIcons } from "../icons/icons.js";
     document.addEventListener("DOMContentLoaded", () => {
       initParticles();
       initIcons();
+      const fab = document.getElementById('feedbackFab');
+      const modal = new bootstrap.Modal(document.getElementById('feedbackModal'));
+      fab.addEventListener('click', () => modal.show());
+      const gmailLink = document.getElementById('feedbackGmail');
+      gmailLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        const to = 'linktracker03@gmail.com';
+        const subject = encodeURIComponent('Product Request / Feedback');
+        const body = encodeURIComponent(`Hey there! I would like to request a new product or send feedback. My email: ${email}`);
+        const url = `https://mail.google.com/mail/?view=cm&fs=1&to=${to}&su=${subject}&body=${body}`;
+        window.open(url, '_blank');
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- support start and end time for each subscription
- skip sending emails outside subscription window
- sort subscribed products first and show time inputs in subscription modal
- expose default time values from subscriptions API
- add contact floating action button on user dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c3551a64c832fa99da9601a4cdcb5