### PR TITLE
Enhance admin contact links for mobile

### DIFF
--- a/web/components/login/login.html
+++ b/web/components/login/login.html
@@ -26,7 +26,7 @@
       <p id="user-error-message" style="display: none; color: red; margin-top: 10px; text-align: center;"></p>
       <div id="user-contact-links" style="display: none;">
         <button id="user-mail-btn" class="btn btn-outline-primary contact-link-btn" type="button"><i data-lucide="mail" class="me-1"></i>Email Admin</button>
-        <a href="https://www.reddit.com/message/compose/?to=ShooBum-T&subject=User%20Registration%20Request" target="_blank" id="user-reddit-link" class="btn btn-outline-danger contact-link-btn"><i data-lucide="message-circle" class="me-1"></i>Message Admin</a>
+        <a href="https://www.reddit.com/message/compose/?to=ShooBum-T&subject=User%20Registration%20Request&message=Please%20register%20my%20email" target="_blank" id="user-reddit-link" class="btn btn-outline-danger contact-link-btn"><i data-lucide="message-circle" class="me-1"></i>Message Admin</a>
       </div>
     </div>
   </div>

--- a/web/components/login/login.js
+++ b/web/components/login/login.js
@@ -190,8 +190,8 @@ export async function initLogin() {
       const subject = encodeURIComponent('Register Amul tracker email');
       const typedEmail = userEmailInput ? userEmailInput.value.trim() : '';
       const body = encodeURIComponent(`Hey there!\nPlease register my email : ${typedEmail}`);
-      const url = `https://mail.google.com/mail/?view=cm&fs=1&to=${to}&su=${subject}&body=${body}`;
-      window.open(url, '_blank');
+      const url = `mailto:${to}?subject=${subject}&body=${body}`;
+      window.location.href = url;
     });
   }
 

--- a/web/components/user-main/user.html
+++ b/web/components/user-main/user.html
@@ -30,7 +30,7 @@
       <h6 class="mb-2">Reach Out</h6>
       <p class="small text-body-secondary">Send a message for bugs, feedback or new product requests.</p>
       <a href="#" id="feedbackGmail" class="btn btn-outline-primary w-100 mb-2"><i data-lucide="mail" class="me-1"></i>Gmail</a>
-      <a href="https://www.reddit.com/message/compose/?to=ShooBum-T&subject=Feedback" target="_blank" id="feedbackReddit" class="btn btn-outline-danger w-100"><i data-lucide="message-circle" class="me-1"></i>Reddit</a>
+      <a href="https://www.reddit.com/message/compose/?to=ShooBum-T&subject=Feedback&message=I%20would%20like%20to%20request%20a%20new%20product%20or%20send%20feedback" target="_blank" id="feedbackReddit" class="btn btn-outline-danger w-100"><i data-lucide="message-circle" class="me-1"></i>Reddit</a>
     </div>
   </div>
 
@@ -135,8 +135,8 @@
         const to = 'linktracker03@gmail.com';
         const subject = encodeURIComponent('Product Request / Feedback');
         const body = encodeURIComponent(`Hey there! I would like to request a new product or send feedback. My email: ${email}`);
-        const url = `https://mail.google.com/mail/?view=cm&fs=1&to=${to}&su=${subject}&body=${body}`;
-        window.open(url, '_blank');
+        const url = `mailto:${to}?subject=${subject}&body=${body}`;
+        window.location.href = url;
       });
    });
   </script>


### PR DESCRIPTION
## Summary
- open email links with `mailto:` scheme so mobile users get their default mail client
- prepopulate Reddit messages for user login and feedback

## Testing
- `pytest -q`
- `python -m py_compile check_stock.py notifications.py scraper.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_684ce71821fc832fa8d69912e96d5fa2