### PR TITLE
Improve mobile experience

### DIFF
--- a/web/components/user-subscriptions/user-subscriptions.html
+++ b/web/components/user-subscriptions/user-subscriptions.html
@@ -1,6 +1,12 @@
 <div class="row" id="subscriptions-ui">
   <div class="col-md-6 mb-4">
-    <h4>Your Subscriptions <i id="subscriptions-info-toggle" data-lucide="info" class="lucide-small ms-1" title="Show info" data-bs-toggle="modal" data-bs-target="#subscriptionsInfoModal"></i></h4>
+    <h4>
+      Your Subscriptions
+      <i id="subscriptions-info-toggle" data-lucide="info" class="lucide-small ms-1" title="Show info" data-bs-toggle="modal" data-bs-target="#subscriptionsInfoModal"></i>
+      <a href="#" class="d-sm-none float-end" data-bs-toggle="collapse" data-bs-target="#userSubscribedListCollapse" aria-expanded="true" aria-controls="userSubscribedListCollapse">
+        <i data-lucide="chevron-down"></i>
+      </a>
+    </h4>
     <div class="modal fade" id="subscriptionsInfoModal" tabindex="-1" aria-labelledby="subscriptionsInfoModalLabel" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
@@ -20,13 +26,19 @@
         </div>
       </div>
     </div>
-    <div class="list-wrapper">
+    <div class="collapse show list-wrapper" id="userSubscribedListCollapse">
       <ul id="user-subscribed-list" class="list-group"></ul>
     </div>
   </div>
   <div class="col-md-6 mb-4">
+    <div class="d-flex justify-content-between align-items-center">
+      <h4>Available Products</h4>
+      <a href="#" class="d-sm-none" data-bs-toggle="collapse" data-bs-target="#allProductsListCollapse" aria-expanded="true" aria-controls="allProductsListCollapse">
+        <i data-lucide="chevron-down"></i>
+      </a>
+    </div>
     <input type="text" id="product-search" class="form-control mb-2" placeholder="Search products">
-    <div class="list-wrapper">
+    <div class="collapse show list-wrapper" id="allProductsListCollapse">
       <ul id="all-products-list" class="list-group"></ul>
     </div>
   </div>

--- a/web/style.css
+++ b/web/style.css
@@ -372,6 +372,13 @@ button, .btn {
     max-height: calc(100vh - 250px);
     overflow-y: auto;
 }
+
+@media (max-width: 767.98px) {
+  #subscriptions-ui .list-wrapper {
+    max-height: none;
+    overflow-y: visible;
+  }
+}
 #subscription-product-list .form-check-input {
     /* border-color: rgba(255,255,255,0.5); */ /* Conflicting border, handled by more specific rule */
 }
@@ -762,6 +769,12 @@ button, .btn {
   color: #333333;
 }
 
+@media (max-width: 767.98px) {
+  #settingsPane.offcanvas-end {
+    width: 50vw;
+  }
+}
+
 #settingsPane .offcanvas-header {
   border-bottom: 1px solid rgba(209, 213, 219, 0.3);
 }
@@ -950,6 +963,16 @@ button, .btn {
 #welcome-msg.shrunk {
   font-size: 1.75rem;
   text-align: start;
+}
+
+@media (max-width: 576px) {
+  #welcome-msg.initial {
+    font-size: 1.8rem;
+    word-break: break-word;
+  }
+  #welcome-msg.shrunk {
+    font-size: 1.5rem;
+  }
 }
 
 @keyframes welcomeBounce {


### PR DESCRIPTION
## Summary
- tweak greeting header font size for small screens
- allow subscription lists to expand freely on mobile
- shrink settings pane width on narrow displays
- add collapsible toggles for subscription lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ceb9b723c832f9f25a32dd36a8df4