### PR TITLE
Add loaders for user UI operations

### DIFF
--- a/web/components/login/login.js
+++ b/web/components/login/login.js
@@ -1,6 +1,8 @@
 import { API_LOGIN, API_USER_LOGIN } from '../config/config.js';
+import { showGlobalLoader, hideGlobalLoader } from '../utils/utils.js';
 
 export async function initLogin() {
+  showGlobalLoader();
   let loginPopup = document.getElementById('login-popup');
   if (!loginPopup) {
     try {
@@ -44,6 +46,7 @@ export async function initLogin() {
 
 
   function showLoginPopup() {
+    hideGlobalLoader();
     if (loginPopup) {
       loginPopup.style.display = 'flex';
     }
@@ -98,6 +101,7 @@ export async function initLogin() {
 
   if (adminLoginBtn) {
     adminLoginBtn.addEventListener('click', async () => {
+      showGlobalLoader();
       const email = adminEmailInput ? adminEmailInput.value.trim() : '';
       const password = adminPasswordInput ? adminPasswordInput.value.trim() : '';
 
@@ -133,6 +137,8 @@ export async function initLogin() {
           adminErrorMessage.textContent = 'Login failed.';
           adminErrorMessage.style.display = 'block';
         }
+      } finally {
+        hideGlobalLoader();
       }
     });
   }
@@ -140,6 +146,7 @@ export async function initLogin() {
   // New User Login Logic
   if (userLoginBtn) {
     userLoginBtn.addEventListener('click', async () => {
+      showGlobalLoader();
       const email = userEmailInput ? userEmailInput.value.trim() : '';
 
       if (email === '') {
@@ -180,6 +187,8 @@ export async function initLogin() {
           userErrorMessage.textContent = 'Login failed.';
           userErrorMessage.style.display = 'block';
         }
+      } finally {
+        hideGlobalLoader();
       }
     });
   }

--- a/web/components/user-main/user.html
+++ b/web/components/user-main/user.html
@@ -11,6 +11,11 @@
 <body>
   <div id="particles-js" style="position: fixed; width: 100%; height: 100%; z-index: -1; top: 0; left: 0;"></div>
   <div id="particles-js-bg"></div>
+  <div id="global-loader" class="loading-overlay" style="display:none;">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  </div>
   <div class="container py-5">
     <p id="welcome-msg" class="mb-4 fw-bold initial"></p>
     <div id="user-subscriptions-container"></div>
@@ -118,8 +123,10 @@
     import { initIcons } from "../icons/icons.js";
     import { initBackground } from "../ui/ui.js";
     import { initUserSubscriptionsUI } from "../user-subscriptions/user-subscriptions.js";
+    import { showGlobalLoader, hideGlobalLoader } from "../utils/utils.js";
 
     document.addEventListener("DOMContentLoaded", async () => {
+      showGlobalLoader();
       initParticles();
       initIcons();
       initBackground();
@@ -130,7 +137,8 @@
       } catch (e) {
         console.error('Failed to load subscription UI', e);
       }
-      initUserSubscriptionsUI();
+      await initUserSubscriptionsUI();
+      hideGlobalLoader();
       const gmailLink = document.getElementById('feedbackGmail');
       gmailLink.addEventListener('click', (e) => {
         e.preventDefault();

--- a/web/components/user-subscriptions/user-subscriptions.js
+++ b/web/components/user-subscriptions/user-subscriptions.js
@@ -1,6 +1,7 @@
-import { fetchAPI } from '../utils/utils.js';
+import { fetchAPI, showGlobalLoader, hideGlobalLoader } from '../utils/utils.js';
 
 export async function initUserSubscriptionsUI() {
+  showGlobalLoader();
   const email = localStorage.getItem('userEmail');
   if (!email) {
     window.location.href = '../../index.html';
@@ -128,6 +129,7 @@ export async function initUserSubscriptionsUI() {
   }
 
   async function subscribe(productId) {
+    showGlobalLoader();
     try {
       const res = await fetchAPI('/api/subscriptions', {
         method: 'POST',
@@ -138,10 +140,13 @@ export async function initUserSubscriptionsUI() {
       render();
     } catch (err) {
       alert(err.message || 'Failed to subscribe');
+    } finally {
+      hideGlobalLoader();
     }
   }
 
   async function unsubscribe(productId) {
+    showGlobalLoader();
     try {
       await fetchAPI('/api/subscriptions', {
         method: 'DELETE',
@@ -152,6 +157,8 @@ export async function initUserSubscriptionsUI() {
       render();
     } catch (err) {
       alert(err.message || 'Failed to unsubscribe');
+    } finally {
+      hideGlobalLoader();
     }
   }
 
@@ -159,6 +166,7 @@ export async function initUserSubscriptionsUI() {
     const li = subscribedList.querySelector(`li[data-product-id="${productId}"]`);
     const start = li ? li.querySelector('.sub-start').value : '00:00';
     const end = li ? li.querySelector('.sub-end').value : '23:59';
+    showGlobalLoader();
     try {
       await fetchAPI('/api/subscriptions', {
         method: 'DELETE',
@@ -172,12 +180,14 @@ export async function initUserSubscriptionsUI() {
     pausedMap.set(productId, { start_time: start, end_time: end });
     savePaused(pausedMap);
     render();
+    hideGlobalLoader();
   }
 
   async function resume(productId) {
     const li = subscribedList.querySelector(`li[data-product-id="${productId}"]`);
     const start = li ? li.querySelector('.sub-start').value : (pausedMap.get(productId)?.start_time || '00:00');
     const end = li ? li.querySelector('.sub-end').value : (pausedMap.get(productId)?.end_time || '23:59');
+    showGlobalLoader();
     try {
       const res = await fetchAPI('/api/subscriptions', {
         method: 'POST',
@@ -190,13 +200,17 @@ export async function initUserSubscriptionsUI() {
       render();
     } catch (err) {
       alert(err.message || 'Failed to resume');
+    } finally {
+      hideGlobalLoader();
     }
   }
 
   async function updateTimes(productId, start, end) {
+    showGlobalLoader();
     if (pausedMap.has(productId) && !subscribedMap.has(productId)) {
       pausedMap.set(productId, { start_time: start, end_time: end });
       savePaused(pausedMap);
+      hideGlobalLoader();
       return;
     }
     try {
@@ -208,6 +222,8 @@ export async function initUserSubscriptionsUI() {
       subscribedMap.set(productId, res);
     } catch (err) {
       alert(err.message || 'Failed to update times');
+    } finally {
+      hideGlobalLoader();
     }
   }
 
@@ -287,6 +303,7 @@ export async function initUserSubscriptionsUI() {
   }
 
   render();
+  hideGlobalLoader();
 }
 
 // Initialization is handled by the page that loads this component

--- a/web/components/utils/utils.js
+++ b/web/components/utils/utils.js
@@ -92,3 +92,13 @@ export async function fetchAPI(url, options) {
   }
   return response.json();
 }
+
+export function showGlobalLoader() {
+  const loader = document.getElementById('global-loader');
+  if (loader) loader.style.display = 'flex';
+}
+
+export function hideGlobalLoader() {
+  const loader = document.getElementById('global-loader');
+  if (loader) loader.style.display = 'none';
+}

--- a/web/index.html
+++ b/web/index.html
@@ -13,6 +13,11 @@
   <!-- Login UI moved to components/login/login.html -->
   <div id="particles-js" style="position: fixed; width: 100%; height: 100%; z-index: -1; top: 0; left: 0;"></div>
   <div id="particles-js-bg"></div> <!-- Div for animated gradient background -->
+  <div id="global-loader" class="loading-overlay" style="display:none;">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.0/dist/jszip.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/web/style.css
+++ b/web/style.css
@@ -1015,3 +1015,17 @@ button, .btn {
 .product-item-hidden {
   display: none !important;
 }
+
+/* Overlay shown during async operations */
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}


### PR DESCRIPTION
## Summary
- show global loader overlay during async work
- display loader when login UI and subscriptions load
- show loaders for subscribe, unsubscribe, pause/resume and time updates

## Testing
- `npm test` *(fails: Missing script)*
- `python -m py_compile check_stock.py scraper.py notifications.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_684d0973cd18832fad10308fb1524571