### PR TITLE
Fix stored XSS with product URLs

### DIFF
--- a/web/api/products.js
+++ b/web/api/products.js
@@ -68,7 +68,10 @@ export default async function handler(req, res) {
           return res.status(400).json({ message: 'Invalid URL' });
         }
         try {
-          new URL(url); // Validate URL format
+          const parsed = new URL(url);
+          if (!['http:', 'https:'].includes(parsed.protocol)) {
+            return res.status(400).json({ message: 'URL must start with http:// or https://' });
+          }
         } catch (_) {
           return res.status(400).json({ message: 'Invalid URL format' });
         }
@@ -109,7 +112,10 @@ export default async function handler(req, res) {
           return res.status(400).json({ message: 'Invalid URL' });
         }
         try {
-          new URL(url);
+          const parsed = new URL(url);
+          if (!['http:', 'https:'].includes(parsed.protocol)) {
+            return res.status(400).json({ message: 'URL must start with http:// or https://' });
+          }
         } catch (_) {
           return res.status(400).json({ message: 'Invalid URL format' });
         }

--- a/web/components/user-main/user.html
+++ b/web/components/user-main/user.html
@@ -69,7 +69,8 @@
       }
       function updateWelcome() {
         const username = localStorage.getItem(`username_${email}`) || "";
-        const hi = username ? `Hi ${username}!` : "Hi!";
+        const safeName = escapeHTML(username);
+        const hi = username ? `Hi ${safeName}!` : "Hi!";
         const mailPart = username ? '' : ` ${email}`;
         const icon = username ? '' : ` <i id="edit-username" data-lucide="edit" class="ms-1" role="button" style="cursor:pointer"></i>`;
         welcomeEl.innerHTML = `${hi} ${getGreeting()},${mailPart}${icon}`;
@@ -123,7 +124,7 @@
     import { initIcons } from "../icons/icons.js";
     import { initBackground } from "../ui/ui.js";
     import { initUserSubscriptionsUI } from "../user-subscriptions/user-subscriptions.js";
-    import { showGlobalLoader, hideGlobalLoader } from "../utils/utils.js";
+    import { showGlobalLoader, hideGlobalLoader, escapeHTML } from "../utils/utils.js";
 
     document.addEventListener("DOMContentLoaded", async () => {
       showGlobalLoader();

--- a/web/components/user-subscriptions/user-subscriptions.js
+++ b/web/components/user-subscriptions/user-subscriptions.js
@@ -1,4 +1,4 @@
-import { fetchAPI, showGlobalLoader, hideGlobalLoader } from '../utils/utils.js';
+import { fetchAPI, showGlobalLoader, hideGlobalLoader, sanitizeUrl } from '../utils/utils.js';
 
 export async function initUserSubscriptionsUI() {
   showGlobalLoader();
@@ -60,10 +60,15 @@ export async function initUserSubscriptionsUI() {
     nameEl.className = 'product-name mb-0';
     nameEl.textContent = product.name;
     const linkEl = document.createElement('a');
-    linkEl.href = product.url;
+    const safeUrl = sanitizeUrl(product.url);
+    linkEl.href = safeUrl || '#';
     linkEl.target = '_blank';
     linkEl.className = 'product-url d-block small';
-    linkEl.innerHTML = `${product.url} <i data-lucide="external-link" class="lucide-xs"></i>`;
+    linkEl.textContent = `${product.url} `;
+    const icon = document.createElement('i');
+    icon.setAttribute('data-lucide', 'external-link');
+    icon.className = 'lucide-xs';
+    linkEl.appendChild(icon);
     details.appendChild(nameEl);
     details.appendChild(linkEl);
 
@@ -96,7 +101,17 @@ export async function initUserSubscriptionsUI() {
     const link = document.createElement('small');
     link.className = 'd-block text-muted';
     const displayUrl = product.url.length > 30 ? product.url.substring(0, 27) + '...' : product.url;
-    link.innerHTML = `<a href="${product.url}" target="_blank" title="${product.url}">${displayUrl} <i data-lucide="external-link" class="lucide-small"></i></a>`;
+    const anchor = document.createElement('a');
+    const safeUrl = sanitizeUrl(product.url);
+    anchor.href = safeUrl || '#';
+    anchor.target = '_blank';
+    anchor.title = product.url;
+    anchor.textContent = `${displayUrl} `;
+    const icon2 = document.createElement('i');
+    icon2.setAttribute('data-lucide', 'external-link');
+    icon2.className = 'lucide-small';
+    anchor.appendChild(icon2);
+    link.appendChild(anchor);
     info.appendChild(strong);
     info.appendChild(link);
 

--- a/web/components/utils/utils.js
+++ b/web/components/utils/utils.js
@@ -13,6 +13,28 @@ export function createRipple(event) {
   button.appendChild(circle);
 }
 
+export function sanitizeUrl(url) {
+  try {
+    const parsed = new URL(url, window.location.origin);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.href;
+    }
+  } catch (_) {
+    // ignore invalid URLs
+  }
+  return '';
+}
+
+export function escapeHTML(str) {
+  return str.replace(/[&<>'"]/g, c => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]));
+}
+
 export function cleanLogText(logText) {
   if (!logText) return '';
   const lines = logText.split('\n');


### PR DESCRIPTION
## Summary
- validate URLs on the API to only allow http or https
- sanitize product URLs before inserting into DOM
- escape usernames before inserting into DOM
- provide helpers `sanitizeUrl` and `escapeHTML`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d36d348d4832faace232ceb5f2f5c