### PR TITLE
Truncate subscription URLs

### DIFF
--- a/web/components/user-subscriptions/user-subscriptions.js
+++ b/web/components/user-subscriptions/user-subscriptions.js
@@ -64,7 +64,9 @@ export async function initUserSubscriptionsUI() {
     linkEl.href = safeUrl || '#';
     linkEl.target = '_blank';
     linkEl.className = 'product-url d-block small';
-    linkEl.textContent = `${product.url} `;
+    linkEl.title = product.url;
+    const displayUrl = product.url.length > 30 ? product.url.substring(0, 27) + '...' : product.url;
+    linkEl.textContent = `${displayUrl} `;
     const icon = document.createElement('i');
     icon.setAttribute('data-lucide', 'external-link');
     icon.className = 'lucide-xs';


### PR DESCRIPTION
## Summary
- truncate long URLs in user subscription list for consistency with available products list

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d66c43c20832fbe8115f9598cccc0