### PR TITLE
Allow users to manage subscriptions without admin token

### DIFF
--- a/web/api/subscriptions.js
+++ b/web/api/subscriptions.js
@@ -1,5 +1,4 @@
 import { kv } from '@vercel/kv';
-import { requireAdmin } from './auth.js';
 
 async function getFromKV(key) {
   try {
@@ -25,7 +24,6 @@ export default async function handler(req, res) {
 
   switch (method) {
       case 'POST':
-        if (!requireAdmin(req, res)) return;
         try {
           const { recipient_id, product_id, start_time, end_time, paused } = req.body || {};
         if (!recipient_id || !product_id) {
@@ -80,7 +78,6 @@ export default async function handler(req, res) {
       break;
 
     case 'DELETE':
-      if (!requireAdmin(req, res)) return;
       try {
         const { recipient_id, product_id } = req.body;
         if (!recipient_id || !product_id) {


### PR DESCRIPTION
## Summary
- relax auth requirements for subscription POST and DELETE so regular users can subscribe/unsubscribe without a JWT

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d81117b58832fa944f132f25e859b