### PR TITLE
Fix greeting alignment

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -426,6 +426,7 @@ button, .btn {
   /* Welcome Message Adjustments for Small Screens */
   #welcome-msg {
     margin-top: 1rem;
+    margin-left: 1rem;
   }
   #welcome-msg.initial {
     font-size: 1.5rem; /* Original was 1.8rem, adjusted from plan to be less drastic */
@@ -988,6 +989,7 @@ button, .btn {
   font-weight: 700;
   transition: all 0.6s ease;
   margin-top: 1.5rem; /* Added margin-top */
+  margin-left: 2rem;
 }
 
 #welcome-msg.initial {
@@ -1734,6 +1736,7 @@ button, .btn {
 #welcome-msg {
   font-weight: 700;
   transition: all 0.6s ease;
+  margin-left: 2rem;
 }
 
 #welcome-msg.initial {
@@ -1748,6 +1751,9 @@ button, .btn {
 }
 
 @media (max-width: 576px) {
+  #welcome-msg {
+    margin-left: 1rem;
+  }
   #welcome-msg.initial {
     font-size: 1.8rem;
     word-break: break-word;
@@ -2571,6 +2577,7 @@ button, .btn {
 #welcome-msg {
   font-weight: 700;
   transition: all 0.6s ease;
+  margin-left: 2rem;
 }
 
 #welcome-msg.initial {
@@ -2585,6 +2592,9 @@ button, .btn {
 }
 
 @media (max-width: 576px) {
+  #welcome-msg {
+    margin-left: 1rem;
+  }
   #welcome-msg.initial {
     font-size: 1.8rem;
     word-break: break-word;


### PR DESCRIPTION
## Summary
- align `#welcome-msg` with header text on desktop and mobile screens

## Testing
- `python -m py_compile check_stock.py scraper.py config.py notifications.py`
- `pytest`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d957838c8832fa03b53d1569d2aa9