### PR TITLE
Improve collapse icon UX on mobile

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -359,14 +359,14 @@ button, .btn {
   margin-right: 0.25rem;
 }
 
-#subscriptions-ui .collapse-toggle .lucide {
+#subscriptions-ui .collapse-toggle svg {
   width: 2em;
   height: 2em;
   stroke-width: 3;
   transition: transform 0.2s ease;
 }
 
-#subscriptions-ui .collapse-toggle.collapsed .lucide {
+#subscriptions-ui .collapse-toggle.collapsed svg {
   transform: rotate(-90deg);
 }
 
@@ -1136,14 +1136,14 @@ button, .btn {
   margin-right: 0.25rem;
 }
 
-#subscriptions-ui .collapse-toggle .lucide {
+#subscriptions-ui .collapse-toggle svg {
   width: 2em;
   height: 2em;
   stroke-width: 3;
   transition: transform 0.2s ease;
 }
 
-#subscriptions-ui .collapse-toggle.collapsed .lucide {
+#subscriptions-ui .collapse-toggle.collapsed svg {
   transform: rotate(-90deg);
 }
 
@@ -1983,14 +1983,14 @@ button, .btn {
   margin-right: 0.25rem;
 }
 
-#subscriptions-ui .collapse-toggle .lucide {
+#subscriptions-ui .collapse-toggle svg {
   width: 2em;
   height: 2em;
   stroke-width: 3;
   transition: transform 0.2s ease;
 }
 
-#subscriptions-ui .collapse-toggle.collapsed .lucide {
+#subscriptions-ui .collapse-toggle.collapsed svg {
   transform: rotate(-90deg);
 }
 


### PR DESCRIPTION
## Summary
- enlarge collapse icons in mobile view
- rotate icon when list is collapsed

## Testing
- `pytest -q`
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684d97138858832f8da795b5b9706110