### PR TITLE
Set user login as default

### DIFF
--- a/web/components/login/login.html
+++ b/web/components/login/login.html
@@ -1,10 +1,10 @@
 <div id="login-popup" style="display: none;">
   <div class="login-container">
     <div class="login-role-selector">
-      <button id="admin-role-btn"><i data-lucide="shield" class="me-1"></i>Admin</button>
       <button id="user-role-btn"><i data-lucide="user" class="me-1"></i>User</button>
+      <button id="admin-role-btn"><i data-lucide="shield" class="me-1"></i>Admin</button>
     </div>
-    <div id="admin-section">
+    <div id="admin-section" style="display: none;">
       <div class="input-icon-wrapper">
         <i data-lucide="mail" class="input-icon"></i>
         <input type="email" id="admin-email" placeholder="Email">
@@ -16,7 +16,7 @@
       <p id="admin-error-message" class="error-message" style="display: none;"></p>
       <button id="admin-login-btn"><i data-lucide="log-in" class="me-1"></i>Login</button>
     </div>
-    <div id="user-section" style="display: none;">
+    <div id="user-section">
       <h4 class="user-login-header" style="margin-bottom: 1.5rem;">Enter your email to login</h4>
       <div class="input-icon-wrapper" id="user-email-wrapper">
         <i data-lucide="mail" class="input-icon"></i>

--- a/web/components/login/login.js
+++ b/web/components/login/login.js
@@ -101,11 +101,11 @@ export async function initLogin() {
     if (loginPopup) {
       loginPopup.style.display = 'flex';
     }
-    if (adminSection) adminSection.style.display = 'block';
-    if (userSection) userSection.style.display = 'none';
+    if (adminSection) adminSection.style.display = 'none';
+    if (userSection) userSection.style.display = 'block';
 
-    if (adminRoleBtn) adminRoleBtn.classList.add('active');
-    if (userRoleBtn) userRoleBtn.classList.remove('active');
+    if (userRoleBtn) userRoleBtn.classList.add('active');
+    if (adminRoleBtn) adminRoleBtn.classList.remove('active');
 
     // Initial state for User Section when popup shows (though it's hidden by default)
     // This will also be reset when user tab is clicked


### PR DESCRIPTION
## Summary
- flip login selector button order and hide admin section by default
- show User tab by default in login popup

## Testing
- `npm test --prefix web || true`
- `pytest || true`


------
https://chatgpt.com/codex/tasks/task_e_684d9d4f7144832fb3247bb6e3ae1517