### PR TITLE
Make header sticky on mobile

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -423,9 +423,14 @@ button, .btn {
   /* Page Header Adjustments for Small Screens */
   .page-header {
     padding: 0.75rem 0;
-    position: sticky;
+    position: fixed;
     top: 0;
+    left: 0;
+    width: 100%;
     z-index: 1020;
+  }
+  body {
+    padding-top: 4.5rem;
   }
   .page-header h1 {
     font-size: 1.25rem;


### PR DESCRIPTION
## Summary
- keep the page header visible when scrolling on small screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684da069b314832faf38e63e10cb6146