### PR TITLE
Improve user login messaging

### DIFF
--- a/web/components/login/login.html
+++ b/web/components/login/login.html
@@ -26,7 +26,7 @@
       <p id="user-error-message" style="display: none; color: red; margin-top: 10px; text-align: center;"></p>
       <div id="user-contact-links" style="display: none;">
         <button id="user-mail-btn" class="btn btn-outline-primary contact-link-btn" type="button"><i data-lucide="mail" class="me-1"></i>Email Admin</button>
-        <a href="https://www.reddit.com/message/compose/?to=ShooBum-T&subject=User%20Registration%20Request&message=Please%20register%20my%20email" target="_blank" id="user-reddit-link" class="btn btn-outline-danger contact-link-btn"><i data-lucide="message-circle" class="me-1"></i>Message Admin</a>
+        <a href="#" id="user-reddit-link" class="btn btn-outline-danger contact-link-btn"><i data-lucide="message-circle" class="me-1"></i>Message Admin</a>
       </div>
     </div>
   </div>

--- a/web/components/login/login.js
+++ b/web/components/login/login.js
@@ -39,6 +39,7 @@ export async function initLogin() {
   // const userContactAdminText = document.getElementById('user-contact-admin-btn'); // REMOVED - Element deleted from HTML
   const userContactLinks = document.getElementById('user-contact-links');
   const userMailBtn = document.getElementById('user-mail-btn');
+  const userRedditLink = document.getElementById('user-reddit-link');
 
   // REMOVE: Old user registration button declarations (userRegYesBtn, userRegNoBtn)
   // const userRegYesBtn = document.getElementById('user-reg-yes');
@@ -270,9 +271,9 @@ export async function initLogin() {
           if (result.attempt) {
             msg = `Email unregistered or incorrect attempt (${result.attempt}/3)`;
             if (result.attempt === 2) msg += ' - last attempt';
-            msg += '. Please contact admin to register.';
+            msg += '. Please contact admin to register via options below';
           } else {
-            msg = result.message || 'Email not registered. Please contact admin to register.';
+            msg = result.message || 'Email not registered. Please contact admin to register via options below';
           }
           if (userErrorMessage) {
             userErrorMessage.textContent = msg;
@@ -312,6 +313,19 @@ export async function initLogin() {
         url = `https://mail.google.com/mail/?view=cm&fs=1&to=${to}&su=${subject}&body=${body}`;
         window.open(url, '_blank');
       }
+    });
+  }
+
+  if (userRedditLink) {
+    userRedditLink.addEventListener('click', (e) => {
+      e.preventDefault();
+      const baseUrl = 'https://www.reddit.com/message/compose/';
+      const to = 'ShooBum-T';
+      const subject = encodeURIComponent('User Registration Request');
+      const typedEmail = userEmailInput ? userEmailInput.value.trim() : '';
+      const message = encodeURIComponent(`Please register my email : ${typedEmail}`);
+      const url = `${baseUrl}?to=${to}&subject=${subject}&message=${message}`;
+      window.open(url, '_blank');
     });
   }
 


### PR DESCRIPTION
## Summary
- enhance user login messages to point users to admin contact options
- inject typed email when opening the Reddit contact link

## Testing
- `npm --prefix web run test` *(fails: missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68512949c684832f8f5fbe7ecfb6d311