### PR TITLE
Add pip and Playwright caches to CI

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -12,7 +12,17 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
-        with: {python-version: "3.x"}
+        with:
+          python-version: "3.x"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-playwright-
 
       - name: Install deps
         run: |


### PR DESCRIPTION
## Summary
- enable pip caching in `actions/setup-python`
- add a step to cache Playwright browsers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851689e0cf4832f927251f7033f998b