### PR TITLE
Optimize Playwright installation

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: pw-browsers
     steps:
       - uses: actions/checkout@v4
 
@@ -20,14 +22,14 @@ jobs:
       - name: Cache Playwright browsers
         uses: actions/cache@v3
         with:
-          path: ~/.cache/ms-playwright
+          path: pw-browsers
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/requirements.txt') }}
           restore-keys: ${{ runner.os }}-playwright-
 
       - name: Install deps
         run: |
           pip install -r requirements.txt
-          playwright install
+          playwright install chromium
 
       - name: Run stock checker
         env:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The workflow definition lives in `.github/workflows/schedule.yml` and runs every
    cd amul-lassi-tracker
    pip install -r requirements.txt
    ```
-   Playwright needs browser binaries so run `playwright install` if you plan to execute the script locally.
+   Playwright needs browser binaries so run `playwright install chromium` if you plan to execute the script locally. The GitHub Actions workflow also installs only Chromium to speed up jobs.
 
 2. **Set up environment variables**
    - `PINCODE` – the postal code used on the Amul store.


### PR DESCRIPTION
## Summary
- only install the Chromium browser in the workflow
- cache Playwright binaries in `pw-browsers`
- document Chromium-only install in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685176bc76c4832f9301a4817bb08f32