### PR TITLE
Fix badges in ToDoReadMe

### DIFF
--- a/ToDoReadMe.md
+++ b/ToDoReadMe.md
@@ -1,13 +1,13 @@
 # TODO & Roadmap 🚧
 
 <!-- Codecov (needs the GH Action upload before it shows % instead of unknown) -->
-[![Coverage](https://img.shields.io/codecov/c/github/tyagishubham177/MyScraper?logo=codecov&logoColor=white&label=coverage)](https://codecov.io/gh/tyagishubham177/MyScraper)
+[![Coverage](https://codecov.io/gh/tyagishubham177/MyScraper/branch/main/graph/badge.svg)](https://codecov.io/gh/tyagishubham177/MyScraper)
 
 <!-- CodeFactor grade (pulls latest grade for main branch) -->
-[![CodeFactor](https://img.shields.io/codefactor/grade/github/tyagishubham177/MyScraper/main?logo=codefactor)](https://www.codefactor.io/repository/github/tyagishubham177/MyScraper/overview/main)
+[![CodeFactor](https://www.codefactor.io/repository/github/tyagishubham177/MyScraper/badge)](https://www.codefactor.io/repository/github/tyagishubham177/MyScraper/overview/main)
 
 <!-- 🔒 OpenSSF Scorecard (zero setup; auto-scans public repos) -->
-[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/tyagishubham177/MyScraper?label=OpenSSF%20Scorecard&logo=openssf)](https://securityscorecards.dev/viewer/?uri=github.com/tyagishubham177/MyScraper)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/tyagishubham177/MyScraper/badge)](https://securityscorecards.dev/viewer/?uri=github.com/tyagishubham177/MyScraper)
 
 
 


### PR DESCRIPTION
## Summary
- update badge URLs in `ToDoReadMe.md` so they render correctly

## Testing
- `python -m py_compile check_stock.py scraper.py config.py notifications.py`


------
https://chatgpt.com/codex/tasks/task_e_68523ffabb74832f8662f093a340122f