### PR TITLE
Reduce method complexity

### DIFF
--- a/web/api/products.js
+++ b/web/api/products.js
@@ -45,138 +45,147 @@ async function saveSubscriptionsToKV(subscriptionsArray) {
 }
 
 // Main request handler
+async function handleGet(req, res) {
+  try {
+    const products = await getProductsFromKV();
+    res.status(200).json(products);
+  } catch (error) {
+    console.error("Error in GET /api/products:", error);
+    res.status(500).json({ message: 'Error retrieving products from KV', error: error.message });
+  }
+}
+
+async function handlePost(req, res) {
+  if (!requireAdmin(req, res)) return;
+  try {
+    const { url, name } = req.body;
+
+    if (!url || typeof url !== 'string') {
+      return res.status(400).json({ message: 'Invalid URL' });
+    }
+    try {
+      const parsed = new URL(url);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return res.status(400).json({ message: 'URL must start with http:// or https://' });
+      }
+    } catch (_) {
+      return res.status(400).json({ message: 'Invalid URL format' });
+    }
+    if (!name || typeof name !== 'string' || name.trim() === '') {
+      return res.status(400).json({ message: 'Invalid product name' });
+    }
+
+    const currentProducts = await getProductsFromKV();
+    if (currentProducts.find(p => p.url === url)) {
+      return res.status(409).json({ message: 'Product with this URL already exists' });
+    }
+
+    const newProduct = {
+      id: String(Date.now()),
+      url: url,
+      name: name.trim()
+    };
+
+    currentProducts.push(newProduct);
+    await saveProductsToKV(currentProducts);
+    res.status(201).json(newProduct);
+  } catch (error) {
+    console.error("Error in POST /api/products:", error);
+    res.status(500).json({ message: 'Error saving product to KV', error: error.message });
+  }
+}
+
+async function handlePut(req, res) {
+  if (!requireAdmin(req, res)) return;
+  try {
+    const { id } = req.query;
+    const { url, name } = req.body;
+
+    if (!id) {
+      return res.status(400).json({ message: 'Product ID is required' });
+    }
+    if (!url || typeof url !== 'string') {
+      return res.status(400).json({ message: 'Invalid URL' });
+    }
+    try {
+      const parsed = new URL(url);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return res.status(400).json({ message: 'URL must start with http:// or https://' });
+      }
+    } catch (_) {
+      return res.status(400).json({ message: 'Invalid URL format' });
+    }
+    if (!name || typeof name !== 'string' || name.trim() === '') {
+      return res.status(400).json({ message: 'Invalid product name' });
+    }
+
+    let currentProducts = await getProductsFromKV();
+    const productIndex = currentProducts.findIndex(p => p.id === id);
+    if (productIndex === -1) {
+      return res.status(404).json({ message: 'Product not found' });
+    }
+    currentProducts[productIndex] = {
+      ...currentProducts[productIndex],
+      url,
+      name: name.trim()
+    };
+    await saveProductsToKV(currentProducts);
+    res.status(200).json(currentProducts[productIndex]);
+  } catch (error) {
+    console.error('Error in PUT /api/products:', error);
+    res.status(500).json({ message: 'Error updating product in KV', error: error.message });
+  }
+}
+
+async function handleDelete(req, res) {
+  if (!requireAdmin(req, res)) return;
+  try {
+    const { id: productIdToDelete } = req.query;
+
+    if (!productIdToDelete) {
+      return res.status(400).json({ message: 'Product ID is required' });
+    }
+
+    let currentProducts = await getProductsFromKV();
+    const productIndex = currentProducts.findIndex(p => p.id === productIdToDelete);
+
+    if (productIndex === -1) {
+      return res.status(404).json({ message: 'Product not found' });
+    }
+
+    const updatedProducts = currentProducts.filter(p => p.id !== productIdToDelete);
+    await saveProductsToKV(updatedProducts);
+
+    let currentSubscriptions = await getSubscriptionsFromKV();
+    const updatedSubscriptions = currentSubscriptions.filter(s => s.product_id !== productIdToDelete);
+
+    if (updatedSubscriptions.length < currentSubscriptions.length) {
+      await saveSubscriptionsToKV(updatedSubscriptions);
+    }
+
+    res.status(200).json({ message: 'Product and associated subscriptions deleted successfully' });
+  } catch (error) {
+    console.error("Error in DELETE /api/products:", error);
+    res.status(500).json({ message: 'Error deleting product from KV', error: error.message });
+  }
+}
+
 export default async function handler(req, res) {
   const { method } = req;
 
   switch (method) {
     case 'GET':
-      try {
-        const products = await getProductsFromKV();
-        res.status(200).json(products);
-      } catch (error) {
-        console.error("Error in GET /api/products:", error);
-        res.status(500).json({ message: 'Error retrieving products from KV', error: error.message });
-      }
+      await handleGet(req, res);
       break;
-
     case 'POST':
-      if (!requireAdmin(req, res)) return;
-      try {
-        const { url, name } = req.body;
-
-        if (!url || typeof url !== 'string') {
-          return res.status(400).json({ message: 'Invalid URL' });
-        }
-        try {
-          const parsed = new URL(url);
-          if (!['http:', 'https:'].includes(parsed.protocol)) {
-            return res.status(400).json({ message: 'URL must start with http:// or https://' });
-          }
-        } catch (_) {
-          return res.status(400).json({ message: 'Invalid URL format' });
-        }
-        if (!name || typeof name !== 'string' || name.trim() === '') {
-          return res.status(400).json({ message: 'Invalid product name' });
-        }
-
-        const currentProducts = await getProductsFromKV();
-        if (currentProducts.find(p => p.url === url)) {
-          return res.status(409).json({ message: 'Product with this URL already exists' });
-        }
-
-        const newProduct = {
-          id: String(Date.now()), // Simple ID generation
-          url: url,
-          name: name.trim(),
-        };
-
-        currentProducts.push(newProduct);
-        await saveProductsToKV(currentProducts);
-        res.status(201).json(newProduct);
-      } catch (error) {
-        console.error("Error in POST /api/products:", error);
-        res.status(500).json({ message: 'Error saving product to KV', error: error.message });
-      }
+      await handlePost(req, res);
       break;
-
     case 'PUT':
-      if (!requireAdmin(req, res)) return;
-      try {
-        const { id } = req.query;
-        const { url, name } = req.body;
-
-        if (!id) {
-          return res.status(400).json({ message: 'Product ID is required' });
-        }
-        if (!url || typeof url !== 'string') {
-          return res.status(400).json({ message: 'Invalid URL' });
-        }
-        try {
-          const parsed = new URL(url);
-          if (!['http:', 'https:'].includes(parsed.protocol)) {
-            return res.status(400).json({ message: 'URL must start with http:// or https://' });
-          }
-        } catch (_) {
-          return res.status(400).json({ message: 'Invalid URL format' });
-        }
-        if (!name || typeof name !== 'string' || name.trim() === '') {
-          return res.status(400).json({ message: 'Invalid product name' });
-        }
-
-        let currentProducts = await getProductsFromKV();
-        const productIndex = currentProducts.findIndex(p => p.id === id);
-        if (productIndex === -1) {
-          return res.status(404).json({ message: 'Product not found' });
-        }
-        currentProducts[productIndex] = {
-          ...currentProducts[productIndex],
-          url,
-          name: name.trim(),
-        };
-        await saveProductsToKV(currentProducts);
-        res.status(200).json(currentProducts[productIndex]);
-      } catch (error) {
-        console.error('Error in PUT /api/products:', error);
-        res.status(500).json({ message: 'Error updating product in KV', error: error.message });
-      }
+      await handlePut(req, res);
       break;
-
     case 'DELETE':
-      if (!requireAdmin(req, res)) return;
-      try {
-        const { id: productIdToDelete } = req.query;
-
-        if (!productIdToDelete) {
-          return res.status(400).json({ message: 'Product ID is required' });
-        }
-
-        let currentProducts = await getProductsFromKV();
-        const productIndex = currentProducts.findIndex(p => p.id === productIdToDelete);
-
-        if (productIndex === -1) {
-          return res.status(404).json({ message: 'Product not found' });
-        }
-
-        // Filter out the product
-        const updatedProducts = currentProducts.filter(p => p.id !== productIdToDelete);
-        await saveProductsToKV(updatedProducts);
-
-        // Remove associated subscriptions
-        let currentSubscriptions = await getSubscriptionsFromKV();
-        const updatedSubscriptions = currentSubscriptions.filter(s => s.product_id !== productIdToDelete);
-
-        // Save subscriptions only if they changed
-        if (updatedSubscriptions.length < currentSubscriptions.length) {
-            await saveSubscriptionsToKV(updatedSubscriptions);
-        }
-
-        res.status(200).json({ message: 'Product and associated subscriptions deleted successfully' });
-      } catch (error) {
-        console.error("Error in DELETE /api/products:", error);
-        res.status(500).json({ message: 'Error deleting product from KV', error: error.message });
-      }
+      await handleDelete(req, res);
       break;
-
     default:
       res.setHeader('Allow', ['GET', 'POST', 'PUT', 'DELETE']);
       res.status(405).json({ message: `Method ${method} Not Allowed` });

--- a/web/api/subscriptions.js
+++ b/web/api/subscriptions.js
@@ -19,119 +19,129 @@ async function saveToKV(key, data) {
   }
 }
 
+
+async function handlePost(req, res) {
+  try {
+    const { recipient_id, product_id, start_time, end_time, paused } = req.body || {};
+    if (!recipient_id || !product_id) {
+      return res.status(400).json({ message: 'Recipient ID and Product ID are required' });
+    }
+
+    const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)$/;
+    const start = timeRegex.test(start_time) ? start_time : '00:00';
+    const end = timeRegex.test(end_time) ? end_time : '23:59';
+
+    const recipients = await getFromKV('recipients');
+    if (!recipients.some(r => r.id === recipient_id)) {
+      return res.status(404).json({ message: 'Recipient not found' });
+    }
+
+    const products = await getFromKV('products');
+    if (!products.some(p => p.id === product_id)) {
+      return res.status(404).json({ message: 'Product not found' });
+    }
+
+    let subs = await getFromKV('subscriptions');
+    subs = subs.map(s => ({
+      ...s,
+      start_time: s.start_time || '00:00',
+      end_time: s.end_time || '23:59',
+      paused: !!s.paused
+    }));
+    const existing = subs.find(s => s.recipient_id === recipient_id && s.product_id === product_id);
+    if (existing) {
+      existing.start_time = start;
+      existing.end_time = end;
+      existing.paused = !!paused;
+      await saveToKV('subscriptions', subs);
+      return res.status(200).json(existing);
+    }
+
+    const newSub = {
+      id: String(Date.now()),
+      recipient_id,
+      product_id,
+      start_time: start,
+      end_time: end,
+      paused: !!paused
+    };
+    subs.push(newSub);
+    await saveToKV('subscriptions', subs);
+    res.status(201).json(newSub);
+  } catch (error) {
+    console.error('Error in POST /api/subscriptions:', error);
+    res.status(500).json({ message: 'Error creating subscription in KV', error: error.message });
+  }
+}
+
+async function handleDelete(req, res) {
+  try {
+    const { recipient_id, product_id } = req.body;
+    if (!recipient_id || !product_id) {
+      return res.status(400).json({ message: 'Recipient ID and Product ID are required in the request body' });
+    }
+
+    let subs = await getFromKV('subscriptions');
+    subs = subs.map(s => ({
+      ...s,
+      start_time: s.start_time || '00:00',
+      end_time: s.end_time || '23:59',
+      paused: !!s.paused
+    }));
+    const updated = subs.filter(s => !(s.recipient_id === recipient_id && s.product_id === product_id));
+    if (updated.length === subs.length) {
+      return res.status(404).json({ message: 'Subscription not found' });
+    }
+
+    await saveToKV('subscriptions', updated);
+    res.status(200).json({ message: 'Subscription deleted successfully' });
+  } catch (error) {
+    console.error('Error in DELETE /api/subscriptions:', error);
+    res.status(500).json({ message: 'Error deleting subscription from KV', error: error.message });
+  }
+}
+
+async function handleGet(req, res) {
+  try {
+    const { recipient_id, product_id } = req.query;
+    let subs = await getFromKV('subscriptions');
+    subs = subs.map(s => ({
+      ...s,
+      start_time: s.start_time || '00:00',
+      end_time: s.end_time || '23:59',
+      paused: !!s.paused
+    }));
+
+    if (recipient_id && product_id) {
+      return res.status(400).json({ message: 'Provide either recipient_id OR product_id, not both.' });
+    }
+
+    if (recipient_id) {
+      res.status(200).json(subs.filter(s => s.recipient_id === recipient_id));
+    } else if (product_id) {
+      res.status(200).json(subs.filter(s => s.product_id === product_id));
+    } else {
+      res.status(200).json(subs);
+    }
+  } catch (error) {
+    console.error('Error in GET /api/subscriptions:', error);
+    res.status(500).json({ message: 'Error retrieving subscriptions from KV', error: error.message });
+  }
+}
+
 export default async function handler(req, res) {
   const { method } = req;
 
   switch (method) {
-      case 'POST':
-        try {
-          const { recipient_id, product_id, start_time, end_time, paused } = req.body || {};
-        if (!recipient_id || !product_id) {
-          return res.status(400).json({ message: 'Recipient ID and Product ID are required' });
-        }
-
-        const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)$/;
-        const start = timeRegex.test(start_time) ? start_time : '00:00';
-        const end = timeRegex.test(end_time) ? end_time : '23:59';
-
-        const recipients = await getFromKV('recipients');
-        if (!recipients.some(r => r.id === recipient_id)) {
-          return res.status(404).json({ message: 'Recipient not found' });
-        }
-
-        const products = await getFromKV('products');
-        if (!products.some(p => p.id === product_id)) {
-          return res.status(404).json({ message: 'Product not found' });
-        }
-
-        let subs = await getFromKV('subscriptions');
-        subs = subs.map(s => ({
-          ...s,
-          start_time: s.start_time || '00:00',
-          end_time: s.end_time || '23:59',
-          paused: !!s.paused
-        }));
-        const existing = subs.find(s => s.recipient_id === recipient_id && s.product_id === product_id);
-        if (existing) {
-          existing.start_time = start;
-          existing.end_time = end;
-          existing.paused = !!paused;
-          await saveToKV('subscriptions', subs);
-          return res.status(200).json(existing);
-        }
-
-        const newSub = {
-          id: String(Date.now()),
-          recipient_id,
-          product_id,
-          start_time: start,
-          end_time: end,
-          paused: !!paused
-        };
-        subs.push(newSub);
-        await saveToKV('subscriptions', subs);
-        res.status(201).json(newSub);
-      } catch (error) {
-        console.error('Error in POST /api/subscriptions:', error);
-        res.status(500).json({ message: 'Error creating subscription in KV', error: error.message });
-      }
+    case 'POST':
+      await handlePost(req, res);
       break;
-
     case 'DELETE':
-      try {
-        const { recipient_id, product_id } = req.body;
-        if (!recipient_id || !product_id) {
-          return res.status(400).json({ message: 'Recipient ID and Product ID are required in the request body' });
-        }
-
-        let subs = await getFromKV('subscriptions');
-        subs = subs.map(s => ({
-          ...s,
-          start_time: s.start_time || '00:00',
-          end_time: s.end_time || '23:59',
-          paused: !!s.paused
-        }));
-        const updated = subs.filter(s => !(s.recipient_id === recipient_id && s.product_id === product_id));
-        if (updated.length === subs.length) {
-          return res.status(404).json({ message: 'Subscription not found' });
-        }
-
-        await saveToKV('subscriptions', updated);
-        res.status(200).json({ message: 'Subscription deleted successfully' });
-      } catch (error) {
-        console.error('Error in DELETE /api/subscriptions:', error);
-        res.status(500).json({ message: 'Error deleting subscription from KV', error: error.message });
-      }
+      await handleDelete(req, res);
       break;
-
     case 'GET':
-      try {
-        const { recipient_id, product_id } = req.query;
-        let subs = await getFromKV('subscriptions');
-        subs = subs.map(s => ({
-          ...s,
-          start_time: s.start_time || '00:00',
-          end_time: s.end_time || '23:59',
-          paused: !!s.paused
-        }));
-
-        if (recipient_id && product_id) {
-          return res.status(400).json({ message: 'Provide either recipient_id OR product_id, not both.' });
-        }
-
-        if (recipient_id) {
-          res.status(200).json(subs.filter(s => s.recipient_id === recipient_id));
-        } else if (product_id) {
-          res.status(200).json(subs.filter(s => s.product_id === product_id));
-        } else {
-          res.status(200).json(subs);
-        }
-      } catch (error) {
-        console.error('Error in GET /api/subscriptions:', error);
-        res.status(500).json({ message: 'Error retrieving subscriptions from KV', error: error.message });
-      }
+      await handleGet(req, res);
       break;
-
     default:
       res.setHeader('Allow', ['GET', 'POST', 'DELETE']);
       res.status(405).json({ message: `Method ${method} Not Allowed` });

--- a/web/components/runs/runs.js
+++ b/web/components/runs/runs.js
@@ -26,11 +26,10 @@ function parseScraperDecisionsFromLog(logText) {
   return decisions;
 }
 
-export async function fetchRuns() {
-  const acc = document.getElementById('runsAccordion');
-  let skeletonHTML = '';
-  for (let i = 0; i < 3; i++) {
-    skeletonHTML += `
+function createSkeleton(count = 3) {
+  let html = '';
+  for (let i = 0; i < count; i++) {
+    html += `
       <div class="accordion-item">
         <h2 class="accordion-header">
           <button class="accordion-button collapsed skeleton-item" type="button" disabled>
@@ -41,7 +40,267 @@ export async function fetchRuns() {
         </h2>
       </div>`;
   }
-  acc.innerHTML = skeletonHTML;
+  return html;
+}
+
+function createAccordionItem(r, idx) {
+  const headingId = `heading${idx}`;
+  const collapseId = `collapse${idx}`;
+  const formattedDate = formatRunDate(r.created_at);
+  const badge = getStatusBadge(r.status, r.conclusion);
+  return `
+    <h2 class="accordion-header" id="${headingId}">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#${collapseId}" aria-expanded="false" aria-controls="${collapseId}">
+        <i data-lucide="calendar-days" class="me-2"></i> ${formattedDate} ${badge}
+      </button>
+    </h2>
+    <div id="${collapseId}" class="accordion-collapse collapse" aria-labelledby="${headingId}" data-run-id="${r.id}" data-run-url="${r.url}" data-run-created-at="${r.created_at}" data-run-conclusion="${r.conclusion || r.status}">
+      <div class="accordion-body">
+        <ul class="nav nav-tabs" id="runTabs-${idx}" role="tablist">
+          <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="overview-tab-${idx}" data-bs-toggle="tab" data-bs-target="#overview-${idx}" type="button" role="tab" aria-controls="overview-${idx}" aria-selected="true">Overview</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="logs-tab-${idx}" data-bs-toggle="tab" data-bs-target="#logs-${idx}" type="button" role="tab" aria-controls="logs-${idx}" aria-selected="false">Logs</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="artifacts-tab-${idx}" data-bs-toggle="tab" data-bs-target="#artifacts-${idx}" type="button" role="tab" aria-controls="artifacts-${idx}" aria-selected="false">Artifacts</button>
+          </li>
+        </ul>
+        <div class="tab-content pt-2" id="runTabsContent-${idx}">
+          <div class="tab-pane fade show active p-2" id="overview-${idx}" role="tabpanel" aria-labelledby="overview-tab-${idx}">Loading overview...</div>
+          <div class="tab-pane fade p-2" id="logs-${idx}" role="tabpanel" aria-labelledby="logs-tab-${idx}">
+            <input type="text" class="form-control form-control-sm my-2" placeholder="Search logs...">Loading logs...
+          </div>
+          <div class="tab-pane fade p-2" id="artifacts-${idx}" role="tabpanel" aria-labelledby="artifacts-tab-${idx}">Loading artifacts...</div>
+        </div>
+      </div>
+    </div>`;
+}
+
+async function loadOverview(col, idx) {
+  if (col.dataset.overviewLoaded) return;
+  const runId = col.dataset.runId;
+  const runUrl = col.dataset.runUrl;
+  const overviewTabPane = col.querySelector(`#overview-${idx}`);
+  overviewTabPane.innerHTML = 'Loading overview...';
+  try {
+    const info = await fetchAPI(`${API_RUN}?id=${runId}`);
+    const githubLink = info.html_url || runUrl;
+    let html = `<p><a href="${githubLink}" target="_blank" rel="noopener noreferrer">View on GitHub</a></p>`;
+    html += `<p><strong>Status:</strong> ${info.status || (info.step ? info.step.status : 'N/A')}</p>`;
+    html += `<p><strong>Conclusion:</strong> ${info.conclusion || (info.step ? info.step.conclusion : 'N/A')}</p>`;
+    const started = info.started_at || (info.step ? info.step.started_at : null);
+    html += `<p><strong>Started:</strong> ${started ? formatRunDate(started) : 'N/A'}</p>`;
+    const completed = info.completed_at || (info.step ? info.step.completed_at : null);
+    html += `<p><strong>Completed:</strong> ${completed ? formatRunDate(completed) : 'N/A'}</p>`;
+    overviewTabPane.innerHTML = html;
+    col.dataset.overviewLoaded = 'true';
+
+    if (!overviewTabPane.dataset.productSummaryLoaded) {
+      try {
+        const token = localStorage.getItem('authToken');
+        const logRes = await fetch(`${API_LOGS}?id=${runId}`, { headers: { 'Authorization': `Bearer ${token}` } });
+        if (!logRes.ok) throw new Error(`Failed to fetch logs for summary: ${logRes.status}`);
+        const blob = await logRes.blob();
+        const zip = await JSZip.loadAsync(blob);
+        let rawLogText = '';
+        let foundLogFile = false;
+        const normalizedStepName = 'runstockchecker';
+        for (const fname of Object.keys(zip.files)) {
+          const lowerFname = fname.toLowerCase();
+          const normalizedFname = lowerFname.replace(/[\s_]+/g, '');
+          if (normalizedFname.includes(normalizedStepName)) {
+            rawLogText = await zip.files[fname].async('string');
+            foundLogFile = true;
+            break;
+          }
+        }
+        if (!foundLogFile) {
+          for (const fname of Object.keys(zip.files)) {
+            const lowerFname = fname.toLowerCase();
+            if (lowerFname.includes('run_stock_checker') || lowerFname.includes('stock checker') || lowerFname.includes('stock-checker')) {
+              rawLogText = await zip.files[fname].async('string');
+              foundLogFile = true;
+              break;
+            }
+          }
+        }
+        if (!foundLogFile) {
+          const firstFile = Object.keys(zip.files)[0];
+          rawLogText = firstFile ? await zip.files[firstFile].async('string') : 'No log file found in archive.';
+        }
+        const trimmedLog = extractCheckStockLog(rawLogText);
+        const cleanedLogText = cleanLogText(trimmedLog);
+        const scraperDecisions = parseScraperDecisionsFromLog(cleanedLogText);
+        let summaryContentHtml = '<h4 class="mt-3">Product Stock Summary:</h4>';
+        if (scraperDecisions.length > 0) {
+          summaryContentHtml += '<div>';
+          scraperDecisions.forEach(decision => {
+            let statusHtml = '';
+            if (decision.status === 'IN STOCK') {
+              statusHtml = `<span style="color: green;"><i data-lucide="check-circle" class="me-1"></i>IN STOCK</span>`;
+            } else if (decision.status === 'OUT OF STOCK') {
+              statusHtml = `<span style="color: red;"><i data-lucide="x-circle" class="me-1"></i>OUT OF STOCK</span>`;
+            } else {
+              statusHtml = `<span>${decision.status}</span>`;
+            }
+            summaryContentHtml += `<div class="mb-2"><span>${decision.name}: </span><strong>${statusHtml}</strong></div>`;
+          });
+          summaryContentHtml += '</div>';
+          overviewTabPane.innerHTML += summaryContentHtml;
+        } else {
+          overviewTabPane.innerHTML += '<p class="mt-3 text-muted">No product stock decisions found in logs.</p>';
+        }
+        overviewTabPane.dataset.productSummaryLoaded = 'true';
+        if (scraperDecisions.length > 0) {
+          setTimeout(() => {
+            if (typeof lucide !== 'undefined' && lucide && typeof lucide.replace === 'function') {
+              lucide.replace();
+            }
+          }, 50);
+        }
+      } catch (logErr) {
+        console.error(`Error loading or parsing log for product summary (run ${runId}):`, logErr);
+        overviewTabPane.innerHTML += `<p class="text-warning mt-3">Could not load product stock summary: ${logErr.message}</p>`;
+        overviewTabPane.dataset.productSummaryLoaded = 'true';
+      }
+    }
+    overviewTabPane.classList.add('fade-in-content');
+  } catch (err) {
+    overviewTabPane.innerHTML = `<div class="text-danger">Error loading overview: ${err.message}</div>`;
+    overviewTabPane.classList.add('fade-in-content');
+  }
+}
+
+async function loadLogs(col, idx) {
+  const logsTabPane = col.querySelector(`#logs-${idx}`);
+  if (logsTabPane.dataset.loaded) return;
+  logsTabPane.innerHTML = `<input type="text" class="form-control form-control-sm my-2" placeholder="Search logs...">Loading logs...`;
+  const runIdForLog = col.dataset.runId;
+  try {
+    const token = localStorage.getItem('authToken');
+    const logRes = await fetch(`${API_LOGS}?id=${runIdForLog}`, { headers: { 'Authorization': `Bearer ${token}` } });
+    if (!logRes.ok) throw new Error(`Failed to fetch logs: ${logRes.status}`);
+    const blob = await logRes.blob();
+    const zip = await JSZip.loadAsync(blob);
+    let rawLogText = 'No relevant log file found.';
+    let foundLog = false;
+    const normalizedStepName = 'runstockchecker';
+    for (const fname of Object.keys(zip.files)) {
+      const lowerFname = fname.toLowerCase();
+      const normalizedFname = lowerFname.replace(/[\s_]+/g, '');
+      if (normalizedFname.includes(normalizedStepName)) {
+        rawLogText = await zip.files[fname].async('string');
+        foundLog = true;
+        break;
+      }
+    }
+    if (!foundLog) {
+      for (const fname of Object.keys(zip.files)) {
+        const lowerFname = fname.toLowerCase();
+        if (lowerFname.includes('run_stock_checker') || lowerFname.includes('stock checker') || lowerFname.includes('stock-checker')) {
+          rawLogText = await zip.files[fname].async('string');
+          foundLog = true;
+          break;
+        }
+      }
+    }
+    if (!foundLog) {
+      const firstFile = Object.keys(zip.files)[0];
+      if (firstFile) {
+        rawLogText = await zip.files[firstFile].async('string');
+      }
+    }
+    const trimmed = extractCheckStockLog(rawLogText);
+    const cleanedLogText = cleanLogText(trimmed);
+    logsTabPane.innerHTML = `<input type="text" class="form-control form-control-sm my-2" placeholder="Search logs..."><pre class="bg-light border mt-2 p-2 small fade-in-content"></pre>`;
+    const logLines = cleanedLogText.split('\n');
+    const preElement = logsTabPane.querySelector('pre');
+    preElement.textContent = cleanedLogText;
+
+    const searchInput = logsTabPane.querySelector('input[type="text"]');
+    searchInput.addEventListener('input', () => {
+      const searchTerm = searchInput.value.toLowerCase();
+      if (!searchTerm) {
+        preElement.textContent = cleanedLogText;
+        return;
+      }
+      const filteredLines = logLines.filter(line => line.toLowerCase().includes(searchTerm));
+      preElement.textContent = filteredLines.join('\n');
+    });
+
+    logsTabPane.dataset.loaded = 'true';
+  } catch (err) {
+    logsTabPane.innerHTML = `<input type="text" class="form-control form-control-sm my-2" placeholder="Search logs..."><div class="text-danger">Error loading logs: ${err.message}</div>`;
+  }
+}
+
+async function loadArtifacts(col, idx) {
+  const artifactsTabPane = col.querySelector(`#artifacts-${idx}`);
+  if (artifactsTabPane.dataset.loaded) return;
+  artifactsTabPane.textContent = 'Loading artifacts...';
+  const runIdForArtifact = col.dataset.runId;
+  try {
+    const info = await fetchAPI(`${API_RUN}?id=${runIdForArtifact}`);
+    if (info.artifacts && info.artifacts.length) {
+      const carouselId = `carousel-${runIdForArtifact}`;
+      let itemsHtml = '';
+      let isFirstItem = true;
+      let imageCount = 0;
+      const token = localStorage.getItem('authToken');
+      for (const art of info.artifacts) {
+        const zipRes = await fetch(`${API_ARTIFACT}?id=${art.id}`, { headers: { 'Authorization': `Bearer ${token}` } });
+        if (zipRes.ok) {
+          const blob = await zipRes.blob();
+          const zip = await JSZip.loadAsync(blob);
+          for (const fname of Object.keys(zip.files)) {
+            if (fname.toLowerCase().endsWith('.png')) {
+              const data = await zip.files[fname].async('base64');
+              itemsHtml += `<div class="carousel-item ${isFirstItem ? 'active' : ''}"><img src="data:image/png;base64,${data}" class="d-block w-100"></div>`;
+              isFirstItem = false;
+              imageCount += 1;
+            }
+          }
+        }
+      }
+      if (itemsHtml) {
+        artifactsTabPane.innerHTML = `
+          <div id="${carouselId}" class="carousel slide mt-3 fade-in-content" data-bs-touch="true">
+            <div class="carousel-inner">${itemsHtml}</div>
+            <button class="carousel-control-prev" type="button" data-bs-target="#${carouselId}" data-bs-slide="prev">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span><span class="visually-hidden">Previous</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#${carouselId}" data-bs-slide="next">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span><span class="visually-hidden">Next</span>
+            </button>
+            <div class="carousel-counter"></div>
+          </div>`;
+        const carouselEl = artifactsTabPane.querySelector(`#${carouselId}`);
+        const counterEl = carouselEl.querySelector('.carousel-counter');
+        const updateCounter = () => {
+          const items = carouselEl.querySelectorAll('.carousel-item');
+          const active = carouselEl.querySelector('.carousel-item.active');
+          const index = Array.from(items).indexOf(active) + 1;
+          counterEl.textContent = `${index}/${imageCount}`;
+        };
+        updateCounter();
+        carouselEl.addEventListener('slid.bs.carousel', updateCounter);
+      } else {
+        artifactsTabPane.innerHTML = '<p class="fade-in-content">No PNG artifacts found.</p>';
+      }
+    } else {
+      artifactsTabPane.innerHTML = '<p class="fade-in-content">No artifacts associated with this run.</p>';
+    }
+    artifactsTabPane.dataset.loaded = 'true';
+  } catch (err) {
+    artifactsTabPane.innerHTML = `<div class="text-danger">Error loading artifacts: ${err.message}</div>`;
+  }
+}
+
+export async function fetchRuns() {
+  const acc = document.getElementById('runsAccordion');
+  acc.innerHTML = createSkeleton();
   try {
     const data = await fetchAPI(API_RUNS);
     if (!data.runs || !data.runs.length) {
@@ -52,299 +311,22 @@ export async function fetchRuns() {
     data.runs.forEach((r, idx) => {
       const item = document.createElement('div');
       item.className = 'accordion-item';
-      const headingId = `heading${idx}`;
-      const collapseId = `collapse${idx}`;
-      const formattedDate = formatRunDate(r.created_at);
-      const badge = getStatusBadge(r.status, r.conclusion);
-      item.innerHTML = `
-        <h2 class="accordion-header" id="${headingId}">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#${collapseId}" aria-expanded="false" aria-controls="${collapseId}">
-            <i data-lucide="calendar-days" class="me-2"></i> ${formattedDate} ${badge}
-          </button>
-        </h2>
-        <div id="${collapseId}" class="accordion-collapse collapse" aria-labelledby="${headingId}" data-run-id="${r.id}" data-run-url="${r.url}" data-run-created-at="${r.created_at}" data-run-conclusion="${r.conclusion || r.status}">
-          <div class="accordion-body">
-            <ul class="nav nav-tabs" id="runTabs-${idx}" role="tablist">
-              <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="overview-tab-${idx}" data-bs-toggle="tab" data-bs-target="#overview-${idx}" type="button" role="tab" aria-controls="overview-${idx}" aria-selected="true">Overview</button>
-              </li>
-              <li class="nav-item" role="presentation">
-                <button class="nav-link" id="logs-tab-${idx}" data-bs-toggle="tab" data-bs-target="#logs-${idx}" type="button" role="tab" aria-controls="logs-${idx}" aria-selected="false">Logs</button>
-              </li>
-              <li class="nav-item" role="presentation">
-                <button class="nav-link" id="artifacts-tab-${idx}" data-bs-toggle="tab" data-bs-target="#artifacts-${idx}" type="button" role="tab" aria-controls="artifacts-${idx}" aria-selected="false">Artifacts</button>
-              </li>
-            </ul>
-            <div class="tab-content pt-2" id="runTabsContent-${idx}">
-              <div class="tab-pane fade show active p-2" id="overview-${idx}" role="tabpanel" aria-labelledby="overview-tab-${idx}">Loading overview...</div>
-              <div class="tab-pane fade p-2" id="logs-${idx}" role="tabpanel" aria-labelledby="logs-tab-${idx}">
-                <input type="text" class="form-control form-control-sm my-2" placeholder="Search logs...">Loading logs...
-              </div>
-              <div class="tab-pane fade p-2" id="artifacts-${idx}" role="tabpanel" aria-labelledby="artifacts-tab-${idx}">Loading artifacts...</div>
-            </div>
-          </div>
-        </div>`;
+      item.innerHTML = createAccordionItem(r, idx);
       acc.appendChild(item);
     });
 
     acc.querySelectorAll('.accordion-collapse').forEach(col => {
-      const numericalIndex = col.id.replace('collapse', '');
-      col.addEventListener('show.bs.collapse', async event => {
-        const currentCollapse = event.target;
-        if (currentCollapse.dataset.overviewLoaded) return;
-        const runId = currentCollapse.dataset.runId;
-        const runUrl = currentCollapse.dataset.runUrl;
-        const overviewTabPane = currentCollapse.querySelector(`#overview-${numericalIndex}`);
-        overviewTabPane.innerHTML = 'Loading overview...';
-        try {
-          const info = await fetchAPI(`${API_RUN}?id=${runId}`);
-          const githubLink = info.html_url || runUrl;
-          let html = `<p><a href="${githubLink}" target="_blank" rel="noopener noreferrer">View on GitHub</a></p>`;
-          html += `<p><strong>Status:</strong> ${info.status || (info.step ? info.step.status : 'N/A')}</p>`;
-          html += `<p><strong>Conclusion:</strong> ${info.conclusion || (info.step ? info.step.conclusion : 'N/A')}</p>`;
-          const started = info.started_at || (info.step ? info.step.started_at : null);
-          html += `<p><strong>Started:</strong> ${started ? formatRunDate(started) : 'N/A'}</p>`;
-          const completed = info.completed_at || (info.step ? info.step.completed_at : null);
-          html += `<p><strong>Completed:</strong> ${completed ? formatRunDate(completed) : 'N/A'}</p>`;
-          overviewTabPane.innerHTML = html; // Set basic overview first
-          currentCollapse.dataset.overviewLoaded = 'true'; // Mark basic overview as loaded
+      const i = col.id.replace('collapse', '');
+      col.addEventListener('show.bs.collapse', () => loadOverview(col, i));
 
-          // --- BEGIN Product Stock Summary Section ---
-          if (!overviewTabPane.dataset.productSummaryLoaded) {
-            try {
-              // Note: This fetches logs specifically for the overview.
-              // For optimization, consider caching/reusing logs if already fetched by the 'Logs' tab.
-              const token = localStorage.getItem('authToken');
-              const logRes = await fetch(`${API_LOGS}?id=${runId}`, {
-                headers: { 'Authorization': `Bearer ${token}` }
-              });
-              if (!logRes.ok) throw new Error(`Failed to fetch logs for summary: ${logRes.status}`);
-
-              const blob = await logRes.blob();
-              const zip = await JSZip.loadAsync(blob);
-              let rawLogText = '';
-              let foundLogFile = false;
-              const normalizedStepName = 'runstockchecker'; // As used in Logs tab
-
-              // Prioritize specific log file names (similar to Logs tab logic)
-              for (const fname of Object.keys(zip.files)) {
-                const lowerFname = fname.toLowerCase();
-                const normalizedFname = lowerFname.replace(/[\s_]+/g, '');
-                if (normalizedFname.includes(normalizedStepName)) {
-                  rawLogText = await zip.files[fname].async('string');
-                  foundLogFile = true;
-                  break;
-                }
-              }
-              if (!foundLogFile) { // Fallback to other common names
-                for (const fname of Object.keys(zip.files)) {
-                  const lowerFname = fname.toLowerCase();
-                  if (lowerFname.includes('run_stock_checker') || lowerFname.includes('stock checker') || lowerFname.includes('stock-checker')) {
-                    rawLogText = await zip.files[fname].async('string');
-                    foundLogFile = true;
-                    break;
-                  }
-                }
-              }
-              if (!foundLogFile) { // Fallback to the first file if no specific match
-                const firstFile = Object.keys(zip.files)[0];
-                if (firstFile) {
-                  rawLogText = await zip.files[firstFile].async('string');
-                } else {
-                  rawLogText = 'No log file found in archive.';
-                }
-              }
-
-              const trimmedLog = extractCheckStockLog(rawLogText);
-              const cleanedLogText = cleanLogText(trimmedLog);
-              const scraperDecisions = parseScraperDecisionsFromLog(cleanedLogText);
-
-              let summaryContentHtml = '<h4 class="mt-3">Product Stock Summary:</h4>';
-              if (scraperDecisions.length > 0) {
-                summaryContentHtml += '<div>'; // Container for product entries
-                scraperDecisions.forEach(decision => {
-                  let statusHtml = '';
-                  if (decision.status === 'IN STOCK') {
-                    statusHtml = `<span style="color: green;"><i data-lucide="check-circle" class="me-1"></i>IN STOCK</span>`;
-                  } else if (decision.status === 'OUT OF STOCK') {
-                    statusHtml = `<span style="color: red;"><i data-lucide="x-circle" class="me-1"></i>OUT OF STOCK</span>`;
-                  } else {
-                    statusHtml = `<span>${decision.status}</span>`; // Fallback for unexpected status
-                  }
-                  summaryContentHtml += `
-                    <div class="mb-2">
-                      <span>${decision.name}: </span>
-                      <strong>${statusHtml}</strong>
-                    </div>`;
-                });
-                summaryContentHtml += '</div>';
-                overviewTabPane.innerHTML += summaryContentHtml;
-              } else {
-                overviewTabPane.innerHTML += '<p class="mt-3 text-muted">No product stock decisions found in logs.</p>';
-              }
-              overviewTabPane.dataset.productSummaryLoaded = 'true';
-
-              // If lucide icons were added, ensure they are rendered.
-              // Assuming a global lucide.replace() might be called by other parts of the app,
-              // or that Bootstrap handles data-lucide. If not, a targeted call would be needed here.
-              if (scraperDecisions.length > 0) {
-                setTimeout(() => {
-                  if (typeof lucide !== 'undefined' && lucide && typeof lucide.replace === 'function') {
-                    lucide.replace();
-                  }
-                }, 50);
-              }
-
-            } catch (logErr) {
-              console.error(`Error loading or parsing log for product summary (run ${runId}):`, logErr);
-              overviewTabPane.innerHTML += `<p class="text-warning mt-3">Could not load product stock summary: ${logErr.message}</p>`;
-              overviewTabPane.dataset.productSummaryLoaded = 'true'; // Mark as loaded even on error to prevent retries
-            }
-          }
-          // --- END Product Stock Summary Section ---
-
-          overviewTabPane.classList.add('fade-in-content'); // Ensure fade-in after all modifications
-
-        } catch (err) {
-          overviewTabPane.innerHTML = `<div class="text-danger">Error loading overview: ${err.message}</div>`;
-           // Also add fade-in for error message
-          overviewTabPane.classList.add('fade-in-content');
-        }
-      });
-
-      const logsTabTrigger = col.querySelector(`#logs-tab-${numericalIndex}`);
-      const logsTabPane = col.querySelector(`#logs-${numericalIndex}`);
-      if (logsTabTrigger && logsTabPane) {
-        logsTabTrigger.addEventListener('shown.bs.tab', async () => {
-          if (logsTabPane.dataset.loaded) return;
-          logsTabPane.innerHTML = `<input type="text" class="form-control form-control-sm my-2" placeholder="Search logs...">Loading logs...`;
-          const runIdForLog = col.dataset.runId;
-          try {
-            const token = localStorage.getItem('authToken');
-            const logRes = await fetch(`${API_LOGS}?id=${runIdForLog}`, {
-              headers: { 'Authorization': `Bearer ${token}` }
-            });
-            if (!logRes.ok) throw new Error(`Failed to fetch logs: ${logRes.status}`);
-            const blob = await logRes.blob();
-            const zip = await JSZip.loadAsync(blob);
-            let rawLogText = 'No relevant log file found.';
-            let foundLog = false;
-            const normalizedStepName = 'runstockchecker';
-            for (const fname of Object.keys(zip.files)) {
-              const lowerFname = fname.toLowerCase();
-              const normalizedFname = lowerFname.replace(/[\s_]+/g, '');
-              if (normalizedFname.includes(normalizedStepName)) {
-                rawLogText = await zip.files[fname].async('string');
-                foundLog = true;
-                break;
-              }
-            }
-            if (!foundLog) {
-              for (const fname of Object.keys(zip.files)) {
-                const lowerFname = fname.toLowerCase();
-                if (lowerFname.includes('run_stock_checker') || lowerFname.includes('stock checker') || lowerFname.includes('stock-checker')) {
-                  rawLogText = await zip.files[fname].async('string');
-                  foundLog = true;
-                  break;
-                }
-              }
-            }
-            if (!foundLog) {
-              const firstFile = Object.keys(zip.files)[0];
-              if (firstFile) {
-                rawLogText = await zip.files[firstFile].async('string');
-              }
-            }
-            const trimmed = extractCheckStockLog(rawLogText);
-            const cleanedLogText = cleanLogText(trimmed);
-            logsTabPane.innerHTML = `<input type="text" class="form-control form-control-sm my-2" placeholder="Search logs..."><pre class="bg-light border mt-2 p-2 small fade-in-content"></pre>`;
-            const logLines = cleanedLogText.split('\n');
-            const preElement = logsTabPane.querySelector('pre');
-            preElement.textContent = cleanedLogText;
-
-            const searchInput = logsTabPane.querySelector('input[type="text"]');
-            searchInput.addEventListener('input', () => {
-              const searchTerm = searchInput.value.toLowerCase();
-              if (!searchTerm) {
-                preElement.textContent = cleanedLogText;
-                return;
-              }
-              const filteredLines = logLines.filter(line => line.toLowerCase().includes(searchTerm));
-              preElement.textContent = filteredLines.join('\n');
-            });
-
-            logsTabPane.dataset.loaded = 'true';
-          } catch (err) {
-            logsTabPane.innerHTML = `<input type="text" class="form-control form-control-sm my-2" placeholder="Search logs..."><div class="text-danger">Error loading logs: ${err.message}</div>`;
-          }
-        }, { once: true });
+      const logsTabTrigger = col.querySelector(`#logs-tab-${i}`);
+      if (logsTabTrigger) {
+        logsTabTrigger.addEventListener('shown.bs.tab', () => loadLogs(col, i), { once: true });
       }
 
-      const artifactsTabTrigger = col.querySelector(`#artifacts-tab-${numericalIndex}`);
-      const artifactsTabPane = col.querySelector(`#artifacts-${numericalIndex}`);
-      if (artifactsTabTrigger && artifactsTabPane) {
-        artifactsTabTrigger.addEventListener('shown.bs.tab', async () => {
-          if (artifactsTabPane.dataset.loaded) return;
-          artifactsTabPane.textContent = 'Loading artifacts...';
-          const runIdForArtifact = col.dataset.runId;
-          try {
-            const info = await fetchAPI(`${API_RUN}?id=${runIdForArtifact}`);
-            if (info.artifacts && info.artifacts.length) {
-              const carouselId = `carousel-${runIdForArtifact}`;
-              let itemsHtml = '';
-              let isFirstItem = true;
-              let imageCount = 0;
-              const token = localStorage.getItem('authToken');
-              for (const art of info.artifacts) {
-                const zipRes = await fetch(`${API_ARTIFACT}?id=${art.id}`, {
-                  headers: { 'Authorization': `Bearer ${token}` }
-                });
-                if (zipRes.ok) {
-                  const blob = await zipRes.blob();
-                  const zip = await JSZip.loadAsync(blob);
-                  for (const fname of Object.keys(zip.files)) {
-                    if (fname.toLowerCase().endsWith('.png')) {
-                      const data = await zip.files[fname].async('base64');
-                      itemsHtml += `<div class="carousel-item ${isFirstItem ? 'active' : ''}"><img src="data:image/png;base64,${data}" class="d-block w-100"></div>`;
-                      isFirstItem = false;
-                      imageCount += 1;
-                    }
-                  }
-                }
-              }
-              if (itemsHtml) {
-                artifactsTabPane.innerHTML = `
-                  <div id="${carouselId}" class="carousel slide mt-3 fade-in-content" data-bs-touch="true">
-                    <div class="carousel-inner">${itemsHtml}</div>
-                    <button class="carousel-control-prev" type="button" data-bs-target="#${carouselId}" data-bs-slide="prev">
-                      <span class="carousel-control-prev-icon" aria-hidden="true"></span><span class="visually-hidden">Previous</span>
-                    </button>
-                    <button class="carousel-control-next" type="button" data-bs-target="#${carouselId}" data-bs-slide="next">
-                      <span class="carousel-control-next-icon" aria-hidden="true"></span><span class="visually-hidden">Next</span>
-                    </button>
-                    <div class="carousel-counter"></div>
-                  </div>`;
-                const carouselEl = artifactsTabPane.querySelector(`#${carouselId}`);
-                const counterEl = carouselEl.querySelector('.carousel-counter');
-                const updateCounter = () => {
-                  const items = carouselEl.querySelectorAll('.carousel-item');
-                  const active = carouselEl.querySelector('.carousel-item.active');
-                  const index = Array.from(items).indexOf(active) + 1;
-                  counterEl.textContent = `${index}/${imageCount}`;
-                };
-                updateCounter();
-                carouselEl.addEventListener('slid.bs.carousel', updateCounter);
-              } else {
-                artifactsTabPane.innerHTML = '<p class="fade-in-content">No PNG artifacts found.</p>';
-              }
-            } else {
-              artifactsTabPane.innerHTML = '<p class="fade-in-content">No artifacts associated with this run.</p>';
-            }
-            artifactsTabPane.dataset.loaded = 'true';
-          } catch (err) {
-            artifactsTabPane.innerHTML = `<div class="text-danger">Error loading artifacts: ${err.message}</div>`;
-          }
-        }, { once: true });
+      const artifactsTabTrigger = col.querySelector(`#artifacts-tab-${i}`);
+      if (artifactsTabTrigger) {
+        artifactsTabTrigger.addEventListener('shown.bs.tab', () => loadArtifacts(col, i), { once: true });
       }
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- refactor `check_stock` into smaller async helpers
- split fetchRuns logic into reusable functions
- break out subscription API handlers
- simplify subscription modal saving
- modularize product API handlers

## Testing
- `python -m py_compile check_stock.py`
- `node --check web/components/runs/runs.js`
- `node --check web/api/subscriptions.js`
- `node --check web/components/subscription/subscription-modal.js`
- `node --check web/api/products.js`

------
https://chatgpt.com/codex/tasks/task_e_68525ae47188832fa4df8cfd070f30e5