### PR TITLE
Refactor complex functions

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -16,82 +16,70 @@ async def _check_availability_on_page(page: Page, url: str, pincode: str, skip_p
     await asyncio.sleep(1)
     await log("Page loaded")
 
-    modal = await page.query_selector("div.modal-content.bg-transparent")
-    if modal:
+    async def handle_pincode_modal():
+        modal = await page.query_selector("div.modal-content.bg-transparent")
+        if not modal:
+            await log("Pincode modal not found")
+            return
         if skip_pincode:
             await log("Pincode modal shown but skipping entry")
-        else:
-            pincode_input_selector = "#search"
-            pincode_input = await page.query_selector(pincode_input_selector)
-            if pincode_input:
-                await log("Pincode input found → typing", pincode)
-                await pincode_input.fill(pincode)
-                await asyncio.sleep(3)
-                await log("Pincode typed")
-                try:
-                    await page.wait_for_selector("#automatic", timeout=5000)
-                    await log("Dropdown shown")
-                except Exception:
-                    await log("Dropdown not detected")
+            return
+        pincode_input = await page.query_selector("#search")
+        if not pincode_input:
+            await log("Pincode input not found in modal")
+            return
+        await log("Pincode input found → typing", pincode)
+        await pincode_input.fill(pincode)
+        await asyncio.sleep(3)
+        await log("Pincode typed")
+        try:
+            await page.wait_for_selector("#automatic", timeout=5000)
+            await log("Dropdown shown")
+        except Exception:
+            await log("Dropdown not detected")
+        suggestion_selector = f"#automatic a.searchitem-name:has-text('{pincode}')"
+        try:
+            await page.wait_for_selector(suggestion_selector, timeout=5000)
+            await page.click(suggestion_selector)
+        except Exception:
+            await log(f"Could not click suggestion for {pincode}, trying keyboard.")
+            await page.keyboard.press("ArrowDown")
+            await page.keyboard.press("Enter")
+        await asyncio.sleep(3)
+        await page.wait_for_load_state('networkidle')
+        await log("Pincode selected/attempted")
 
-                suggestion_selector = f"#automatic a.searchitem-name:has-text('{pincode}')"
-                try:
-                    await page.wait_for_selector(suggestion_selector, timeout=5000)
-                    await page.click(suggestion_selector)
-                except Exception:
-                    await log(f"Could not click suggestion for {pincode}, trying keyboard.")
-                    await page.keyboard.press("ArrowDown")
-                    await page.keyboard.press("Enter")
-                await asyncio.sleep(3)
-                await page.wait_for_load_state('networkidle')
-                await log("Pincode selected/attempted")
-            else:
-                await log("Pincode input not found in modal")
-    else:
-        await log("Pincode modal not found")
+    async def element_visibility(selector: str) -> tuple[bool, str]:
+        elem = await page.query_selector(selector)
+        visible = await elem.is_visible() if elem else False
+        status = "visible" if visible else ("hidden" if elem else "missing")
+        return visible, status
+
+    await handle_pincode_modal()
 
     await log("Checking availability indicators…")
-    sold_out_elem = await page.query_selector("div.alert.alert-danger.mt-3")
-    sold_out_visible = False
-    if sold_out_elem:
-        sold_out_visible = await sold_out_elem.is_visible()
-    so_status = ("visible" if sold_out_visible else ("hidden" if sold_out_elem else "missing"))
+    sold_out_visible, so_status = await element_visibility("div.alert.alert-danger.mt-3")
     await log("Sold Out indicator:", so_status)
 
-    disabled_elem = await page.query_selector("a.btn.btn-primary.add-to-cart.disabled")
-    disabled_visible = False
-    if disabled_elem:
-        disabled_visible = await disabled_elem.is_visible()
-    disabled_btn = disabled_visible
-    db_status = ("visible" if disabled_visible else ("hidden" if disabled_elem else "missing"))
+    disabled_visible, db_status = await element_visibility("a.btn.btn-primary.add-to-cart.disabled")
     await log("Add to Cart disabled:", db_status)
+    disabled_btn = disabled_visible
 
-    notify_elem = await page.query_selector("button.btn.btn-primary.product_enquiry")
-    notify_visible = False
-    if notify_elem:
-        notify_visible = await notify_elem.is_visible()
-    nm_status = ("visible" if notify_visible else ("hidden" if notify_elem else "missing"))
+    notify_visible, nm_status = await element_visibility("button.btn.btn-primary.product_enquiry")
     await log("Notify Me button:", nm_status)
 
-    enabled_elem = await page.query_selector("a.btn.btn-primary.add-to-cart:not(.disabled)")
-    enabled_visible = False
-    if enabled_elem:
-        enabled_visible = await enabled_elem.is_visible()
-    add_btn = enabled_visible
-    ab_status = ("visible" if enabled_visible else ("hidden" if enabled_elem else "missing"))
+    enabled_visible, ab_status = await element_visibility("a.btn.btn-primary.add-to-cart:not(.disabled)")
     await log("Add to Cart enabled:", ab_status)
+    add_btn = enabled_visible
 
-    product_name_element = await page.query_selector("h1.product-name.mb-2.fw-bold.lh-sm.text-dark.h3.mb-4")
     product_name = "The Product"
-    if product_name_element:
-        content = await product_name_element.text_content()
-        if content:
-            product_name = content.strip()
-            await log("Extracted product name:", product_name)
-        else:
-            await log("Product name element found but no text_content. Using default.")
+    elem = await page.query_selector("h1.product-name.mb-2.fw-bold.lh-sm.text-dark.h3.mb-4")
+    if elem:
+        content = await elem.text_content() or ""
+        product_name = content.strip() or product_name
+        await log("Extracted product name:", product_name)
     else:
-        await log("Product name element (h1.product-name.mb-2.fw-bold.lh-sm.text-dark.h3.mb-4) not found. Using default.")
+        await log("Product name element not found. Using default.")
 
     in_stock = add_btn and not sold_out_visible and not disabled_btn
 
@@ -108,12 +96,15 @@ async def _check_availability_on_page(page: Page, url: str, pincode: str, skip_p
     safe_url_part = re.sub(r'[^a-zA-Z0-9_-]', '_', safe_url_part)
     safe_filename = f"artifacts/screenshot_{safe_url_part[:100]}.png"
 
-    try:
-        print(f"Attempting to take screenshot: {safe_filename}")
-        await page.screenshot(path=safe_filename)
-        print(f"Screenshot saved: {safe_filename}")
-    except Exception as e:
-        print(f"Error taking single screenshot for {url}: {e}")
+    async def capture_screenshot():
+        try:
+            print(f"Attempting to take screenshot: {safe_filename}")
+            await page.screenshot(path=safe_filename)
+            print(f"Screenshot saved: {safe_filename}")
+        except Exception as e:
+            print(f"Error taking single screenshot for {url}: {e}")
+
+    await capture_screenshot()
 
     return in_stock, product_name
 


### PR DESCRIPTION
## Summary
- add reusable error helpers for login flows
- simplify admin and user login handlers
- break log parsing logic in run overview
- summarize subscription data in notifications
- modularize product check logic
- create helper to record login attempts

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68525ef46470832fa2d4036a43820ef0