### PR TITLE
Fix indentation in notifications

### DIFF
--- a/notifications.py
+++ b/notifications.py
@@ -156,7 +156,6 @@ def format_summary_email_body(run_timestamp_str: str, summary_data_list: list, t
 
         return subscribed_emails_csv, product_status_overall
 
-"""
     for product_data in summary_data_list:
         product_name = product_data.get("product_name", "N/A")
         product_url = product_data.get("product_url", "#")


### PR DESCRIPTION
## Summary
- fix indentation at the end of `format_summary_email_body`

## Testing
- `python -m py_compile notifications.py check_stock.py`


------
https://chatgpt.com/codex/tasks/task_e_6852649f8c14832f9956c58619a780cd