### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary
- configure Dependabot to keep Python packages up to date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526474dc14832fbfd5969fb747a170