### PR TITLE
Restrict schedule workflow permissions

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -5,6 +5,9 @@ on:
     - cron: "*/15 * * * *"   # every 15 min
   workflow_dispatch:        # manual run button
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- limit GITHUB_TOKEN scope in the scheduled job

## Testing
- `python -m py_compile $(ls *.py)`

------
https://chatgpt.com/codex/tasks/task_e_6852703c3c50832f8592dec4d0c4ed63