### PR TITLE
Add initial tests for project modules

### DIFF
--- a/tests/test_check_stock.py
+++ b/tests/test_check_stock.py
@@ -1,0 +1,66 @@
+import asyncio
+from datetime import time as dt_time
+import pytest
+import sys
+import types
+
+# Provide dummy modules for optional dependencies
+sys.modules.setdefault('aiohttp', types.ModuleType('aiohttp'))
+playwright_module = types.ModuleType('playwright')
+playwright_async = types.ModuleType('playwright.async_api')
+playwright_async.async_playwright = lambda: None
+playwright_async.Page = object
+playwright_module.async_api = playwright_async
+sys.modules.setdefault('playwright', playwright_module)
+sys.modules.setdefault('playwright.async_api', playwright_async)
+
+import scripts.config as config_module
+sys.modules.setdefault('config', config_module)
+import scripts.notifications as notifications_module
+sys.modules.setdefault('notifications', notifications_module)
+import scripts.scraper as scraper_module
+sys.modules.setdefault('scraper', scraper_module)
+
+from scripts import check_stock, config, notifications
+
+
+def test_within_time_window_simple():
+    now = dt_time(12, 0)
+    assert check_stock.within_time_window('10:00', '13:00', now)
+    assert not check_stock.within_time_window('13:01', '14:00', now)
+    assert check_stock.within_time_window('23:00', '01:00', dt_time(23, 30))
+
+
+def test_filter_active_subs():
+    now = dt_time(9, 0)
+    subs = [
+        {'paused': True},
+        {'start_time': '08:00', 'end_time': '10:00'},
+        {'start_time': '10:00', 'end_time': '12:00'},
+    ]
+    active = check_stock.filter_active_subs(subs, now)
+    assert len(active) == 1
+
+
+async def _run_notify_users(monkeypatch):
+    sent_args = {}
+    async def dummy_send_email(*args, **kwargs):
+        sent_args['called'] = True
+    monkeypatch.setattr(notifications, 'send_email_notification', dummy_send_email)
+    monkeypatch.setattr(config, 'EMAIL_HOST', 'smtp')
+    monkeypatch.setattr(config, 'EMAIL_SENDER', 'sender@example.com')
+    monkeypatch.setattr(config, 'EMAIL_PORT', 587)
+    monkeypatch.setattr(config, 'EMAIL_HOST_USER', '')
+    monkeypatch.setattr(config, 'EMAIL_HOST_PASSWORD', '')
+    subs = [{'recipient_id': 1, 'start_time': '00:00', 'end_time': '23:59'}]
+    recipients = {1: 'user@example.com'}
+    result, count = await check_stock.notify_users('Prod', 'url', subs, recipients, dt_time(12,0))
+    return result, count, sent_args
+
+
+@pytest.mark.asyncio
+async def test_notify_users(monkeypatch):
+    result, count, sent = await _run_notify_users(monkeypatch)
+    assert count == 1
+    assert sent.get('called')
+    assert result[0]['status'] == 'Sent'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,10 @@
+import importlib
+import os
+
+
+def test_environment_overrides(monkeypatch):
+    monkeypatch.setenv('EMAIL_PORT', '2525')
+    monkeypatch.setenv('APP_BASE_URL', 'http://example.com')
+    config = importlib.reload(importlib.import_module('scripts.config'))
+    assert config.EMAIL_PORT == 2525
+    assert config.APP_BASE_URL == 'http://example.com'

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,4 +1,0 @@
-import pytest
-
-def test_placeholder():
-    assert True

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,72 @@
+import smtplib
+from scripts import notifications
+
+
+def test_format_messages():
+    long_html = notifications.format_long_message('Prod', 'http://x')
+    assert 'Prod' in long_html and 'http://x' in long_html
+    short_msg = notifications.format_short_message('Prod')
+    assert 'Prod' in short_msg
+
+def test_send_email_notification(monkeypatch):
+    sent = {}
+
+    class DummySMTP:
+        def __init__(self, host, port):
+            sent['host'] = host
+            sent['port'] = port
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def starttls(self):
+            sent['starttls'] = True
+        def login(self, user, pwd):
+            sent['login'] = (user, pwd)
+        def sendmail(self, sender, recipients, msg):
+            sent['message'] = msg
+            sent['recipients'] = recipients
+            sent['sender'] = sender
+
+    monkeypatch.setattr(smtplib, 'SMTP', DummySMTP)
+    notifications.send_email_notification(
+        subject='sub',
+        body='body',
+        sender='s@example.com',
+        recipients=['r@example.com'],
+        host='smtp.example.com',
+        port=587,
+        username='u',
+        password='p'
+    )
+    assert sent['host'] == 'smtp.example.com'
+    assert sent['recipients'] == ['r@example.com']
+
+
+def test_send_email_missing_config(monkeypatch):
+    called = False
+    def dummy(*a, **k):
+        nonlocal called
+        called = True
+        return DummySMTP(*a, **k)
+
+    class DummySMTP:
+        def __init__(self, *a, **k):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def sendmail(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(smtplib, 'SMTP', dummy)
+    notifications.send_email_notification(
+        subject='sub',
+        body='body',
+        sender='',
+        recipients=['r@example.com'],
+        host='smtp.example.com',
+        port=587
+    )
+    assert not called

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,35 @@
+import asyncio
+import sys
+import types
+
+# Stub playwright module to avoid dependency during import
+playwright_module = types.ModuleType('playwright')
+async_api = types.ModuleType('playwright.async_api')
+async_api.async_playwright = lambda: None
+async_api.Page = object
+playwright_module.async_api = async_api
+sys.modules.setdefault('playwright', playwright_module)
+sys.modules.setdefault('playwright.async_api', async_api)
+
+from scripts import scraper
+
+
+class DummyPage:
+    pass
+
+
+async def dummy_checker(page, url, pincode, skip):
+    return True, 'Dummy'
+
+def test_check_product_availability_with_page(monkeypatch):
+    called = {}
+
+    async def fake(page, url, pincode, skip):
+        called['args'] = (page, url, pincode, skip)
+        return True, 'Dummy'
+
+    monkeypatch.setattr(scraper, '_check_availability_on_page', fake)
+    page = DummyPage()
+    result = asyncio.run(scraper.check_product_availability('http://x', '123', page=page, skip_pincode=True))
+    assert result == (True, 'Dummy')
+    assert called['args'] == (page, 'http://x', '123', True)


### PR DESCRIPTION
## Summary
- remove placeholder test file
- add configuration tests
- add email notification tests
- test scraper entry function
- cover stock checking helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a349e8ac832fabd342dae35c9b09