### PR TITLE
Improve test coverage

### DIFF
--- a/tests/test_check_stock.py
+++ b/tests/test_check_stock.py
@@ -5,38 +5,41 @@ import sys
 import types
 
 # Provide dummy modules for optional dependencies
-sys.modules.setdefault('aiohttp', types.ModuleType('aiohttp'))
-playwright_module = types.ModuleType('playwright')
-playwright_async = types.ModuleType('playwright.async_api')
+sys.modules.setdefault("aiohttp", types.ModuleType("aiohttp"))
+playwright_module = types.ModuleType("playwright")
+playwright_async = types.ModuleType("playwright.async_api")
 playwright_async.async_playwright = lambda: None
 playwright_async.Page = object
 playwright_module.async_api = playwright_async
-sys.modules.setdefault('playwright', playwright_module)
-sys.modules.setdefault('playwright.async_api', playwright_async)
+sys.modules.setdefault("playwright", playwright_module)
+sys.modules.setdefault("playwright.async_api", playwright_async)
 
 import scripts.config as config_module
-sys.modules.setdefault('config', config_module)
+
+sys.modules.setdefault("config", config_module)
 import scripts.notifications as notifications_module
-sys.modules.setdefault('notifications', notifications_module)
+
+sys.modules.setdefault("notifications", notifications_module)
 import scripts.scraper as scraper_module
-sys.modules.setdefault('scraper', scraper_module)
+
+sys.modules.setdefault("scraper", scraper_module)
 
 from scripts import check_stock, config, notifications
 
 
 def test_within_time_window_simple():
     now = dt_time(12, 0)
-    assert check_stock.within_time_window('10:00', '13:00', now)
-    assert not check_stock.within_time_window('13:01', '14:00', now)
-    assert check_stock.within_time_window('23:00', '01:00', dt_time(23, 30))
+    assert check_stock.within_time_window("10:00", "13:00", now)
+    assert not check_stock.within_time_window("13:01", "14:00", now)
+    assert check_stock.within_time_window("23:00", "01:00", dt_time(23, 30))
 
 
 def test_filter_active_subs():
     now = dt_time(9, 0)
     subs = [
-        {'paused': True},
-        {'start_time': '08:00', 'end_time': '10:00'},
-        {'start_time': '10:00', 'end_time': '12:00'},
+        {"paused": True},
+        {"start_time": "08:00", "end_time": "10:00"},
+        {"start_time": "10:00", "end_time": "12:00"},
     ]
     active = check_stock.filter_active_subs(subs, now)
     assert len(active) == 1
@@ -44,23 +47,104 @@ def test_filter_active_subs():
 
 async def _run_notify_users(monkeypatch):
     sent_args = {}
+
     def dummy_send_email(*args, **kwargs):
-        sent_args['called'] = True
-    monkeypatch.setattr(notifications, 'send_email_notification', dummy_send_email)
-    monkeypatch.setattr(config, 'EMAIL_HOST', 'smtp')
-    monkeypatch.setattr(config, 'EMAIL_SENDER', 'sender@example.com')
-    monkeypatch.setattr(config, 'EMAIL_PORT', 587)
-    monkeypatch.setattr(config, 'EMAIL_HOST_USER', '')
-    monkeypatch.setattr(config, 'EMAIL_HOST_PASSWORD', '')
-    subs = [{'recipient_id': 1, 'start_time': '00:00', 'end_time': '23:59'}]
-    recipients = {1: 'user@example.com'}
-    result, count = await check_stock.notify_users('Prod', 'url', subs, recipients, dt_time(12,0))
+        sent_args["called"] = True
+
+    monkeypatch.setattr(notifications, "send_email_notification", dummy_send_email)
+    monkeypatch.setattr(config, "EMAIL_HOST", "smtp")
+    monkeypatch.setattr(config, "EMAIL_SENDER", "sender@example.com")
+    monkeypatch.setattr(config, "EMAIL_PORT", 587)
+    monkeypatch.setattr(config, "EMAIL_HOST_USER", "")
+    monkeypatch.setattr(config, "EMAIL_HOST_PASSWORD", "")
+    subs = [{"recipient_id": 1, "start_time": "00:00", "end_time": "23:59"}]
+    recipients = {1: "user@example.com"}
+    result, count = await check_stock.notify_users(
+        "Prod", "url", subs, recipients, dt_time(12, 0)
+    )
     return result, count, sent_args
 
 
-@pytest.mark.asyncio
-async def test_notify_users(monkeypatch):
-    result, count, sent = await _run_notify_users(monkeypatch)
+def test_notify_users(monkeypatch):
+    result, count, sent = asyncio.run(_run_notify_users(monkeypatch))
     assert count == 1
-    assert sent.get('called')
-    assert result[0]['status'] == 'Sent'
+    assert sent.get("called")
+    assert result[0]["status"] == "Sent"
+
+
+def test_within_time_window_invalid():
+    now = dt_time(12, 0)
+    # Invalid time strings should default to True
+    assert check_stock.within_time_window("bad", "time", now)
+
+
+def test_process_product_missing_data():
+    summary, sent, pin = asyncio.run(
+        check_stock.process_product(
+            None, None, {"name": "NoID"}, {}, dt_time(12, 0), False
+        )
+    )
+    assert summary is None
+    assert sent == 0
+    assert not pin
+
+
+def test_process_product_out_of_stock(monkeypatch):
+    async def fake_fetch(session, pid):
+        return [{"recipient_id": 1}]
+
+    monkeypatch.setattr(check_stock, "fetch_subscriptions", fake_fetch)
+    monkeypatch.setattr(check_stock, "filter_active_subs", lambda subs, ct: subs)
+
+    async def fake_check(url, pin, page=None, skip_pincode=False):
+        return False, "Scraped"
+
+    monkeypatch.setattr(scraper_module, "check_product_availability", fake_check)
+    recipients = {1: "u@example.com"}
+    summary, sent, pin = asyncio.run(
+        check_stock.process_product(
+            None,
+            object(),
+            {"id": 1, "url": "http://x", "name": "Prod"},
+            recipients,
+            dt_time(12, 0),
+            False,
+        )
+    )
+    assert sent == 0
+    assert summary["product_name"] == "Scraped"
+    assert summary["subscriptions"][0]["status"] == "Not Sent - Out of Stock"
+    assert pin
+
+
+def test_process_product_in_stock(monkeypatch):
+    async def fake_fetch(session, pid):
+        return [{"recipient_id": 1}]
+
+    monkeypatch.setattr(check_stock, "fetch_subscriptions", fake_fetch)
+    monkeypatch.setattr(check_stock, "filter_active_subs", lambda subs, ct: subs)
+
+    async def fake_notify(*a, **k):
+        return ([{"user_email": "u@example.com", "status": "Sent"}], 1)
+
+    monkeypatch.setattr(check_stock, "notify_users", fake_notify)
+
+    async def fake_check(url, pin, page=None, skip_pincode=False):
+        return True, "New"
+
+    monkeypatch.setattr(scraper_module, "check_product_availability", fake_check)
+    recipients = {1: "u@example.com"}
+    summary, sent, pin = asyncio.run(
+        check_stock.process_product(
+            None,
+            object(),
+            {"id": 1, "url": "http://x", "name": "Prod"},
+            recipients,
+            dt_time(12, 0),
+            False,
+        )
+    )
+    assert sent == 1
+    assert summary["product_name"] == "New"
+    assert summary["subscriptions"][0]["status"] == "Sent"
+    assert pin

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -3,48 +3,55 @@ from scripts import notifications
 
 
 def test_format_messages():
-    long_html = notifications.format_long_message('Prod', 'http://x')
-    assert 'Prod' in long_html and 'http://x' in long_html
-    short_msg = notifications.format_short_message('Prod')
-    assert 'Prod' in short_msg
+    long_html = notifications.format_long_message("Prod", "http://x")
+    assert "Prod" in long_html and "http://x" in long_html
+    short_msg = notifications.format_short_message("Prod")
+    assert "Prod" in short_msg
+
 
 def test_send_email_notification(monkeypatch):
     sent = {}
 
     class DummySMTP:
         def __init__(self, host, port):
-            sent['host'] = host
-            sent['port'] = port
+            sent["host"] = host
+            sent["port"] = port
+
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, tb):
             pass
-        def starttls(self):
-            sent['starttls'] = True
-        def login(self, user, pwd):
-            sent['login'] = (user, pwd)
-        def sendmail(self, sender, recipients, msg):
-            sent['message'] = msg
-            sent['recipients'] = recipients
-            sent['sender'] = sender
 
-    monkeypatch.setattr(smtplib, 'SMTP', DummySMTP)
+        def starttls(self):
+            sent["starttls"] = True
+
+        def login(self, user, pwd):
+            sent["login"] = (user, pwd)
+
+        def sendmail(self, sender, recipients, msg):
+            sent["message"] = msg
+            sent["recipients"] = recipients
+            sent["sender"] = sender
+
+    monkeypatch.setattr(smtplib, "SMTP", DummySMTP)
     notifications.send_email_notification(
-        subject='sub',
-        body='body',
-        sender='s@example.com',
-        recipients=['r@example.com'],
-        host='smtp.example.com',
+        subject="sub",
+        body="body",
+        sender="s@example.com",
+        recipients=["r@example.com"],
+        host="smtp.example.com",
         port=587,
-        username='u',
-        password='p'
+        username="u",
+        password="p",
     )
-    assert sent['host'] == 'smtp.example.com'
-    assert sent['recipients'] == ['r@example.com']
+    assert sent["host"] == "smtp.example.com"
+    assert sent["recipients"] == ["r@example.com"]
 
 
 def test_send_email_missing_config(monkeypatch):
     called = False
+
     def dummy(*a, **k):
         nonlocal called
         called = True
@@ -53,20 +60,37 @@ def test_send_email_missing_config(monkeypatch):
     class DummySMTP:
         def __init__(self, *a, **k):
             pass
+
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, tb):
             pass
+
         def sendmail(self, *a, **k):
             pass
 
-    monkeypatch.setattr(smtplib, 'SMTP', dummy)
+    monkeypatch.setattr(smtplib, "SMTP", dummy)
     notifications.send_email_notification(
-        subject='sub',
-        body='body',
-        sender='',
-        recipients=['r@example.com'],
-        host='smtp.example.com',
-        port=587
+        subject="sub",
+        body="body",
+        sender="",
+        recipients=["r@example.com"],
+        host="smtp.example.com",
+        port=587,
     )
     assert not called
+
+
+def test_format_summary_email_body():
+    data = [
+        {
+            "product_name": "Prod",
+            "product_url": "http://x",
+            "subscriptions": [{"user_email": "u@example.com", "status": "Sent"}],
+        }
+    ]
+    html = notifications.format_summary_email_body("run", data, 1)
+    assert "Prod" in html
+    assert "http://x" in html
+    assert "Notification sent" in html

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -3,13 +3,13 @@ import sys
 import types
 
 # Stub playwright module to avoid dependency during import
-playwright_module = types.ModuleType('playwright')
-async_api = types.ModuleType('playwright.async_api')
+playwright_module = types.ModuleType("playwright")
+async_api = types.ModuleType("playwright.async_api")
 async_api.async_playwright = lambda: None
 async_api.Page = object
 playwright_module.async_api = async_api
-sys.modules.setdefault('playwright', playwright_module)
-sys.modules.setdefault('playwright.async_api', async_api)
+sys.modules.setdefault("playwright", playwright_module)
+sys.modules.setdefault("playwright.async_api", async_api)
 
 from scripts import scraper
 
@@ -19,17 +19,63 @@ class DummyPage:
 
 
 async def dummy_checker(page, url, pincode, skip):
-    return True, 'Dummy'
+    return True, "Dummy"
+
 
 def test_check_product_availability_with_page(monkeypatch):
     called = {}
 
     async def fake(page, url, pincode, skip):
-        called['args'] = (page, url, pincode, skip)
-        return True, 'Dummy'
+        called["args"] = (page, url, pincode, skip)
+        return True, "Dummy"
 
-    monkeypatch.setattr(scraper, '_check_availability_on_page', fake)
+    monkeypatch.setattr(scraper, "_check_availability_on_page", fake)
     page = DummyPage()
-    result = asyncio.run(scraper.check_product_availability('http://x', '123', page=page, skip_pincode=True))
-    assert result == (True, 'Dummy')
-    assert called['args'] == (page, 'http://x', '123', True)
+    result = asyncio.run(
+        scraper.check_product_availability(
+            "http://x", "123", page=page, skip_pincode=True
+        )
+    )
+    assert result == (True, "Dummy")
+    assert called["args"] == (page, "http://x", "123", True)
+
+
+def test_check_product_availability_without_page(monkeypatch):
+    called = {}
+
+    async def fake_check(page, url, pincode, skip):
+        called["args"] = (page, url, pincode, skip)
+        return False, "Dummy"
+
+    class DummyBrowser:
+        async def new_page(self):
+            called["new_page"] = True
+            return "page"
+
+        async def close(self):
+            called["closed"] = True
+
+    class DummyChromium:
+        async def launch(self, headless=True, args=None):
+            called["launch"] = True
+            return DummyBrowser()
+
+    class DummyPlaywright:
+        chromium = DummyChromium()
+
+    class DummyManager:
+        async def __aenter__(self):
+            called["enter"] = True
+            return DummyPlaywright()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            called["exit"] = True
+
+    monkeypatch.setattr(scraper, "_check_availability_on_page", fake_check)
+    monkeypatch.setattr(scraper, "async_playwright", lambda: DummyManager())
+
+    result = asyncio.run(scraper.check_product_availability("http://x", "111"))
+    assert result == (False, "Dummy")
+    assert called["args"][0] == "page"
+    assert called["closed"]
+    assert called["enter"] and called["exit"]


### PR DESCRIPTION
## Summary
- add more tests around stock checking logic
- cover summary email rendering
- handle playwright logic without a page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852caf11d60832f88dc8f64cee6077a