### PR TITLE
Add basic web test with coverage

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install web dependencies
         run: |
           cd web
-          npm ci
+          npm install
       - name: Run tests
         run: |
           pytest --cov=. --cov-report=xml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,9 +20,20 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install pytest pytest-cov pytest-asyncio
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install web dependencies
+        run: |
+          cd web
+          npm ci
       - name: Run tests
         run: |
           pytest --cov=. --cov-report=xml
+          cd web
+          npm test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,10 @@
   "name": "web-api",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "NODE_V8_COVERAGE=./coverage node --test --experimental-test-coverage"
+  },
   "dependencies": {
     "@vercel/kv": "^1.0.1",
     "bcryptjs": "^2.4.3",

--- a/web/test/utils.test.js
+++ b/web/test/utils.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'assert';
+import { escapeHTML, formatRunDate, cleanLogText, sanitizeUrl } from '../components/utils/utils.js';
+
+global.window = { location: { origin: 'http://example.com' } };
+
+test('escapeHTML escapes characters', () => {
+  const result = escapeHTML('<div>"A&B\'</div>');
+  assert.equal(result, '&lt;div&gt;&quot;A&amp;B&#39;&lt;/div&gt;');
+});
+
+test('formatRunDate formats ISO strings', () => {
+  const result = formatRunDate('2023-01-02T15:04:00Z');
+  assert.equal(result, '02-Jan-23, 03:04 PM');
+});
+
+test('cleanLogText removes debug prefixes', () => {
+  const log = '2024-01-01T00:00:00Z hello\n##[debug]2024-01-01T00:00:01Z debug info';
+  assert.equal(cleanLogText(log), 'hello\ndebug info');
+});
+
+test('sanitizeUrl filters unsafe protocols', () => {
+  assert.equal(sanitizeUrl('javascript:alert(1)'), '');
+  assert.equal(sanitizeUrl('/path'), 'http://example.com/path');
+});


### PR DESCRIPTION
## Summary
- add minimal Node test for utils
- run web tests in CI
- enable Node module format and test script in `package.json`

## Testing
- `pytest -q` *(fails: ImportError - no module named 'aiohttp')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852da3ece8c832fb6c328ea7d8c5f93