### PR TITLE
Add node coverage generation

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,7 +34,9 @@ jobs:
           pytest --cov=. --cov-report=xml
           cd web
           npm test
+          mv coverage/lcov.info ../coverage-web.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml,coverage-web.lcov

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,14 +27,12 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - name: Install web dependencies
         run: |
-          cd web
-          npm install
+          npm install --prefix web
       - name: Run tests
         run: |
           pytest --cov=. --cov-report=xml
-          cd web
-          npm test
-          mv coverage/lcov.info ../coverage-web.lcov
+          npm --prefix web test
+          mv web/coverage/lcov.info coverage-web.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage.xml
 
 # Scraper artifacts
 artifacts/
+web/coverage/

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,9 @@
         "@vercel/kv": "^1.0.1",
         "bcryptjs": "^2.4.3",
         "jsonwebtoken": "^9.0.2"
+      },
+      "devDependencies": {
+        "c8": "^8.0.1"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -4,11 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "NODE_V8_COVERAGE=./coverage node --test --experimental-test-coverage"
+    "test": "c8 node --test"
   },
   "dependencies": {
     "@vercel/kv": "^1.0.1",
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "c8": "^8.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- generate Node coverage with c8
- move Node lcov to root in CI and upload it
- ignore `web/coverage/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*
- `npm test` *(fails: c8: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e237a090832fa6390ff3241ad0b5