### PR TITLE
Fix Node coverage generation

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "c8 node --test"
+    "test": "c8 --reporter=text --reporter=lcov node --test"
   },
   "dependencies": {
     "@vercel/kv": "^1.0.1",


### PR DESCRIPTION
## Summary
- add lcov reporter when running web tests

## Testing
- `npm --prefix web test` *(fails: c8: not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6852e8014a98832f8554dbd25b494b5a