### PR TITLE
Add tests for multiple web components

### DIFF
--- a/web/components/runs/runs.js
+++ b/web/components/runs/runs.js
@@ -344,3 +344,6 @@ export async function fetchRuns() {
     acc.innerHTML = `<div class="text-danger">Error loading runs. Details: ${e.message}</div>`;
   }
 }
+
+// Export internal helpers for testing
+export { parseScraperDecisionsFromLog, createSkeleton, createAccordionItem };

--- a/web/test/config.test.js
+++ b/web/test/config.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'assert';
+import * as config from '../components/config/config.js';
+
+test('API endpoint constants are defined', () => {
+  assert.equal(config.API_STATUS, '/api/status');
+  assert.equal(config.API_RUNS, '/api/runs');
+  assert.equal(config.API_RUN, '/api/run');
+  assert.equal(config.API_LOGS, '/api/logs');
+  assert.equal(config.API_ARTIFACT, '/api/artifact');
+  assert.equal(config.API_LOGIN, '/api/login');
+  assert.equal(config.API_USER_LOGIN, '/api/user-login');
+});

--- a/web/test/runs.test.js
+++ b/web/test/runs.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'assert';
+import { parseScraperDecisionsFromLog, createSkeleton, createAccordionItem } from '../components/runs/runs.js';
+import { formatRunDate, getStatusBadge } from '../components/utils/utils.js';
+
+test('parseScraperDecisionsFromLog extracts product statuses', () => {
+  const log = `✅ Product 'A' (URL: http://a) is IN STOCK.\n` +
+              `❌ Product 'B' (URL: http://b) is OUT OF STOCK.\n` +
+              `Something else`;
+  const result = parseScraperDecisionsFromLog(log);
+  assert.deepEqual(result, [
+    { name: 'A', status: 'IN STOCK' },
+    { name: 'B', status: 'OUT OF STOCK' }
+  ]);
+});
+
+test('createSkeleton returns requested number of items', () => {
+  const html = createSkeleton(2);
+  const matches = html.match(/accordion-item/g) || [];
+  assert.equal(matches.length, 2);
+});
+
+test('createAccordionItem builds markup with run info', () => {
+  const run = {
+    id: 1,
+    url: 'http://example.com',
+    created_at: '2024-01-02T15:04:00Z',
+    conclusion: 'success'
+  };
+  const html = createAccordionItem(run, 0);
+  assert(html.includes('id="heading0"'));
+  assert(html.includes('id="collapse0"'));
+  assert(html.includes(formatRunDate(run.created_at)));
+  assert(html.includes(getStatusBadge(run.status, run.conclusion)));
+});

--- a/web/test/utils.test.js
+++ b/web/test/utils.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'assert';
-import { escapeHTML, formatRunDate, cleanLogText, sanitizeUrl } from '../components/utils/utils.js';
+import { escapeHTML, formatRunDate, cleanLogText, sanitizeUrl, extractCheckStockLog, getStatusBadge } from '../components/utils/utils.js';
 
 global.window = { location: { origin: 'http://example.com' } };
 
@@ -22,4 +22,15 @@ test('cleanLogText removes debug prefixes', () => {
 test('sanitizeUrl filters unsafe protocols', () => {
   assert.equal(sanitizeUrl('javascript:alert(1)'), '');
   assert.equal(sanitizeUrl('/path'), 'http://example.com/path');
+});
+
+test('extractCheckStockLog trims relevant section', () => {
+  const log = 'start\nLaunching browser\nwork\nRun actions/upload-artifact@v4\nend';
+  assert.equal(extractCheckStockLog(log), 'Launching browser\nwork\n');
+});
+
+test('getStatusBadge renders badge html', () => {
+  const html = getStatusBadge('queued', '');
+  assert(html.includes('loader-2'));
+  assert(html.includes('queued'.charAt(0).toUpperCase() + 'queued'.slice(1))); // 'Queued'
 });


### PR DESCRIPTION
## Summary
- export helpers from `runs.js` for testing
- test API endpoint constants
- cover helpers in `runs.js`
- extend utils tests

## Testing
- `node --test ../web/test/utils.test.js ../web/test/config.test.js ../web/test/runs.test.js`
- `npm test` *(fails: c8 not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6852ed17b3ac832fb9aad3744f317177