### PR TITLE
Add recipients UI tests

### DIFF
--- a/web/test/recipients-ui.test.js
+++ b/web/test/recipients-ui.test.js
@@ -104,7 +104,7 @@ test('renderRecipientsList populates DOM', async () => {
   global.window.lucide.createIcons = () => { created = true; };
   const mod = await loadModule();
   mod.initRecipientsUI();
-  await Promise.resolve();
+  await new Promise(r => setImmediate(r));
   const list = env.elements['recipients-list'];
   assert.equal(list.children.length, 1);
   assert.equal(list.children[0].dataset.recipientId, 1);


### PR DESCRIPTION
## Summary
- add tests for the recipients UI component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*
- `npm test` in `web` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530c949170832fb93ad2cb714b691e