### PR TITLE
Add tests for web UI modules

### DIFF
--- a/web/test/admin-main.test.js
+++ b/web/test/admin-main.test.js
@@ -21,9 +21,10 @@ test('handler redirects to index when no token', async () => {
     getElementById: id => elements[id] || makeEl(),
     createElement: () => makeEl(),
     querySelectorAll: () => [],
+    querySelector: () => null,
     body: Object.assign(makeEl(), { scrollHeight: 0 })
   };
-  global.window = { location: { href: '' } };
+  global.window = { location: { href: '' }, addEventListener(){}, innerHeight:0 };
   global.localStorage = { getItem: () => null };
 
   await import('../components/admin-main/admin-main.js?' + Date.now());
@@ -56,14 +57,17 @@ test('initializes logout handler when token present', async () => {
     getElementById: id => elements[id] || makeEventEl(),
     createElement: () => makeEventEl(),
     querySelectorAll: () => [],
+    querySelector: () => null,
     body: Object.assign(makeEventEl(), { scrollHeight: 0 })
   };
-  global.window = { location: { href: '' } };
+  global.window = { location: { href: '' }, addEventListener(){}, innerHeight:0 };
   let removedToken = false;
   global.localStorage = { getItem: () => 'tok', removeItem: () => { removedToken = true; } };
   global.particlesJS = () => {};
   global.bootstrap = { Tooltip: function(){} };
   global.lucide = { createIcons(){} };
+  global.VanillaTilt = { init(){} };
+  global.fetch = async () => ({ ok:true, status:200, json: async () => ({ runs:[], state:'enabled' }) });
   await import('../components/admin-main/admin-main.js?' + Date.now());
   events['DOMContentLoaded']();
   assert(logoutBtn.getEvent('click'), 'logout click handler added');

--- a/web/test/main.test.js
+++ b/web/test/main.test.js
@@ -28,3 +28,60 @@ test('registers DOMContentLoaded handler', async () => {
   assert(events['DOMContentLoaded']);
 });
 
+
+function makeLoginEl(){
+  return {
+    style:{},
+    classList:{ add(){}, remove(){} },
+    addEventListener(){},
+    prepend(){},
+    appendChild(){},
+    querySelector(){ return null; },
+    querySelectorAll(){ return []; },
+    disabled:false,
+    value:''
+  };
+}
+
+function setupLoginEnv(){
+  const elements = {
+    'login-popup': makeLoginEl(),
+    'admin-role-btn': makeLoginEl(),
+    'user-role-btn': makeLoginEl(),
+    'admin-section': makeLoginEl(),
+    'user-section': makeLoginEl(),
+    'admin-email': makeLoginEl(),
+    'admin-password': makeLoginEl(),
+    'admin-login-btn': makeLoginEl(),
+    'admin-error-message': makeLoginEl(),
+    'user-email': makeLoginEl(),
+    'user-email-wrapper': makeLoginEl(),
+    'user-login-btn': makeLoginEl(),
+    'user-error-message': makeLoginEl(),
+    'user-contact-links': makeLoginEl(),
+    'user-mail-btn': makeLoginEl(),
+    'user-reddit-link': makeLoginEl(),
+    'main-app-content': makeLoginEl(),
+    'global-loader': makeLoginEl()
+  };
+  const events = {};
+  global.document = {
+    addEventListener: (ev, cb) => events[ev] = cb,
+    getElementById: id => elements[id] || makeLoginEl(),
+    createElement: () => makeLoginEl(),
+    body: { prepend(){}, style:{} },
+    querySelector: () => makeLoginEl(),
+    querySelectorAll: () => []
+  };
+  global.window = { location:{ href:'' }, lucide:{ createIcons(){} } };
+  global.localStorage = { getItem: () => null, setItem(){}, removeItem(){} };
+  global.fetch = async () => ({ text: async () => '' });
+  return { elements, events };
+}
+
+test('DOMContentLoaded triggers login popup', async () => {
+  const { elements, events } = setupLoginEnv();
+  await import('../components/main/main.js?' + Date.now());
+  events['DOMContentLoaded']();
+  assert.equal(elements['login-popup'].style.display, 'flex');
+});

--- a/web/test/main.test.js
+++ b/web/test/main.test.js
@@ -73,9 +73,11 @@ function setupLoginEnv(){
     querySelector: () => makeLoginEl(),
     querySelectorAll: () => []
   };
-  global.window = { location:{ href:'' }, lucide:{ createIcons(){} } };
+  global.window = { location:{ href:'' }, lucide:{ createIcons(){} }, addEventListener(){}, innerHeight:0 };
   global.localStorage = { getItem: () => null, setItem(){}, removeItem(){} };
   global.fetch = async () => ({ text: async () => '' });
+  global.particlesJS = () => {};
+  global.VanillaTilt = { init(){} };
   return { elements, events };
 }
 

--- a/web/test/status.test.js
+++ b/web/test/status.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'assert';
+
+function makeEl(){
+  return {
+    style:{},
+    classList:{
+      classes:[],
+      add(...c){ this.classes.push(...c); },
+      remove(...c){ this.classes = this.classes.filter(x=>!c.includes(x)); }
+    },
+    textContent:'',
+  };
+}
+
+test('showLoader and hideLoader update elements', async () => {
+  const loader = makeEl();
+  const status = makeEl();
+  global.document = { getElementById: id => ({loader,status}[id]) };
+  const mod = await import('../components/status/status.js?' + Date.now());
+  mod.showLoader();
+  assert.equal(loader.style.display, 'inline-block');
+  assert(status.classList.classes.includes('status-loading-pulse'));
+  mod.hideLoader();
+  assert.equal(loader.style.display, 'none');
+  assert(!status.classList.classes.includes('status-loading-pulse'));
+});
+
+test('fetchStatus populates status text', async () => {
+  const loader = makeEl();
+  const status = makeEl();
+  global.document = { getElementById: id => ({loader,status}[id]) };
+  global.fetch = async () => ({ ok:true, status:200, json: async () => ({ state:'enabled' }) });
+  global.localStorage = { getItem: () => 'tok' };
+  const mod = await import('../components/status/status.js?' + Date.now());
+  await mod.fetchStatus();
+  assert.equal(status.textContent, 'enabled');
+  assert.equal(loader.style.display, 'none');
+  assert(status.classList.classes.includes('bg-success-subtle'));
+});

--- a/web/test/ui.test.js
+++ b/web/test/ui.test.js
@@ -78,6 +78,6 @@ test('initPage attaches handlers and calls helpers', async () => {
   await mod.initPage();
   assert(elements['refresh'].getEvent('click'), 'refresh handler');
   assert(elements['refresh-runs'].getEvent('click'), 'refresh runs handler');
-  assert(recBtn.getEvent('show.bs.collapse'), 'collapse handler');
+  assert(elements['recipientManagementCollapse'].getEvent('show.bs.collapse'), 'collapse handler');
   assert(fetchCount > 0, 'fetch called');
 });

--- a/web/test/ui.test.js
+++ b/web/test/ui.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'assert';
+
+function makeEl(){
+  const el = {
+    style:{},
+    classList:{ classes:[], add(...c){ this.classes.push(...c); }, remove(...c){ this.classes=this.classes.filter(x=>!c.includes(x)); } },
+    events:{},
+    children:[],
+    addEventListener(ev,cb){ this.events[ev]=cb; },
+    getEvent(ev){ return this.events[ev]; },
+    appendChild(child){ this.children.push(child); },
+    querySelector(){ return null; },
+    querySelectorAll(){ return []; }
+  };
+  Object.defineProperty(el, 'innerHTML', { get(){ return this._html || ''; }, set(v){ this._html=v; } });
+  return el;
+}
+
+function setupBase(){
+  const elements = {
+    'refresh': makeEl(),
+    'refresh-runs': makeEl(),
+    'loader': makeEl(),
+    'status': makeEl(),
+    'runsAccordion': makeEl(),
+    'particles-js-bg': makeEl(),
+    'recipientManagementCollapse': makeEl(),
+    'productManagementCollapse': makeEl()
+  };
+  const recBtn = makeEl();
+  recBtn.querySelector = () => makeEl();
+  const prodBtn = makeEl();
+  prodBtn.querySelector = () => makeEl();
+  global.document = {
+    getElementById: id => elements[id] || makeEl(),
+    createElement: () => makeEl(),
+    querySelector: sel => {
+      if(sel === '[data-bs-target="#recipientManagementCollapse"]') return recBtn;
+      if(sel === '[data-bs-target="#productManagementCollapse"]') return prodBtn;
+      return null;
+    },
+    querySelectorAll: () => [] ,
+    body: makeEl()
+  };
+  global.window = { lucide:{ createIcons(){} }, addEventListener(){}, innerHeight:0 };
+  global.bootstrap = { Tooltip: function(){} };
+  global.particlesJS = () => {};
+  global.VanillaTilt = { init(){} };
+  global.fetch = async () => ({ ok:true, status:200, json: async () => ({ runs: [], state: 'enabled' }) });
+  global.localStorage = { getItem: () => null };
+  return { elements, recBtn, prodBtn };
+}
+
+test('initBackground sets gradient', async () => {
+  const el = makeEl();
+  global.document = { getElementById: () => el };
+  const mod = await import('../components/ui/ui.js?' + Date.now());
+  mod.initBackground();
+  assert(el.style.backgroundImage);
+  assert.equal(el.style.animation, 'none');
+});
+
+test('initBackground logs error when missing', async () => {
+  let logged = false;
+  global.document = { getElementById: () => null };
+  global.console = { error(){ logged = true; } };
+  const mod = await import('../components/ui/ui.js?' + Date.now());
+  mod.initBackground();
+  assert(logged);
+});
+
+test('initPage attaches handlers and calls helpers', async () => {
+  const { elements, recBtn, prodBtn } = setupBase();
+  let fetchCount = 0;
+  global.fetch = async () => { fetchCount++; return { ok:true, status:200, json: async () => ({ runs: [], state:'enabled' }) }; };
+  const mod = await import('../components/ui/ui.js?' + Date.now());
+  await mod.initPage();
+  assert(elements['refresh'].getEvent('click'), 'refresh handler');
+  assert(elements['refresh-runs'].getEvent('click'), 'refresh runs handler');
+  assert(recBtn.getEvent('show.bs.collapse'), 'collapse handler');
+  assert(fetchCount > 0, 'fetch called');
+});


### PR DESCRIPTION
## Summary
- add coverage for admin-main logout handler
- exercise main app initialization
- test status.js logic
- test UI helpers and page initialization

## Testing
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538e32dee8832f96321df6e4c959f8