### PR TITLE
Increase runs.js coverage

### DIFF
--- a/web/components/runs/runs.js
+++ b/web/components/runs/runs.js
@@ -346,4 +346,4 @@ export async function fetchRuns() {
 }
 
 // Export internal helpers for testing
-export { parseScraperDecisionsFromLog, createSkeleton, createAccordionItem };
+export { parseScraperDecisionsFromLog, createSkeleton, createAccordionItem, appendSummary };


### PR DESCRIPTION
## Summary
- expose `appendSummary` in runs component for testing
- cover additional cases in runs.test.js

## Testing
- `npm test` *(fails: c8 not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685392a175e8832f8a04139a9a08ca52