### PR TITLE
Add vercel.json to disable automatic deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
This commit introduces a vercel.json file with the git.deploymentEnabled_false setting to prevent Vercel from automatically deploying on every branch push.