### PR TITLE
Increase login UI coverage

### DIFF
--- a/web/test/login-ui.test.js
+++ b/web/test/login-ui.test.js
@@ -5,7 +5,8 @@ function makeEl() {
   return {
     style: {},
     classList: { add(){ this.added=true; }, remove(){ this.removed=true; } },
-    addEventListener(){},
+    events: {},
+    addEventListener(ev, cb){ this.events[ev] = cb; },
     prepend(){},
     appendChild(){},
     querySelector(){ return null; },
@@ -76,4 +77,109 @@ test('shows login popup when no credentials', async () => {
   const mod = await loadModule();
   await mod.initLogin();
   assert.equal(env.elements['login-popup'].style.display, 'flex');
+});
+
+test('fetches login html when popup missing', async () => {
+  const env = setupEnv();
+  env.elements['login-popup'] = null;
+  let fetched = false;
+  global.fetch = async (url) => {
+    if (url.includes('login.html')) {
+      fetched = true;
+      return { text: async () => '<div id="login-popup"></div>' };
+    }
+    return { json: async () => ({}) , ok: true };
+  };
+  global.document.createElement = () => ({ firstElementChild: { id: 'login-popup', style: {}, classList:{ add(){}, remove(){} } } });
+  global.document.body.prepend = el => { env.elements['login-popup'] = el; };
+  const mod = await loadModule();
+  await mod.initLogin();
+  assert.ok(fetched);
+  assert.ok(env.elements['login-popup']);
+});
+
+test('admin role button shows admin section', async () => {
+  const env = setupEnv();
+  const mod = await loadModule();
+  await mod.initLogin();
+  env.elements['admin-role-btn'].events.click();
+  assert.equal(env.elements['admin-section'].style.display, 'block');
+  assert.equal(env.elements['user-section'].style.display, 'none');
+});
+
+test('user role button shows user section', async () => {
+  const env = setupEnv();
+  const mod = await loadModule();
+  await mod.initLogin();
+  env.elements['user-role-btn'].events.click();
+  assert.equal(env.elements['user-section'].style.display, 'block');
+  assert.equal(env.elements['admin-section'].style.display, 'none');
+});
+
+test('admin login with empty fields shows error', async () => {
+  const env = setupEnv();
+  const mod = await loadModule();
+  await mod.initLogin();
+  env.elements['admin-email'].value = '';
+  env.elements['admin-password'].value = '';
+  await env.elements['admin-login-btn'].events.click();
+  assert.equal(env.elements['admin-error-message'].textContent, 'Please enter both email and password.');
+  assert.equal(env.elements['admin-error-message'].style.display, 'block');
+});
+
+test('admin login shows countdown on lockout', async () => {
+  const env = setupEnv();
+  global.fetch = async (url) => ({ ok: false, json: async () => ({ wait: 1 }) });
+  global.setInterval = (fn) => { fn(); return 1; };
+  const mod = await loadModule();
+  await mod.initLogin();
+  env.elements['admin-email'].value = 'a@a';
+  env.elements['admin-password'].value = 'p';
+  await env.elements['admin-login-btn'].events.click();
+  assert.ok(env.storage['adminLockUntil']);
+  assert.ok(env.elements['admin-login-btn'].disabled);
+});
+
+test('user login blank email shows error', async () => {
+  const env = setupEnv();
+  const mod = await loadModule();
+  await mod.initLogin();
+  env.elements['user-email'].value = '';
+  await env.elements['user-login-btn'].events.click();
+  assert.equal(env.elements['user-error-message'].textContent, 'Please enter your email.');
+  assert.equal(env.elements['user-error-message'].style.display, 'block');
+});
+
+test('user login success redirects', async () => {
+  const env = setupEnv();
+  global.fetch = async () => ({ ok: true, json: async () => ({ token: 't' }) });
+  const mod = await loadModule();
+  await mod.initLogin();
+  env.elements['user-email'].value = 'u@e';
+  await env.elements['user-login-btn'].events.click();
+  assert.equal(global.window.location.href, 'components/user-main/user.html');
+});
+
+test('user mail button opens gmail on desktop', async () => {
+  const env = setupEnv();
+  const mod = await loadModule();
+  await mod.initLogin();
+  let opened = '';
+  global.window.open = (url) => { opened = url; };
+  global.window.navigator = { userAgent: 'desktop' };
+  global.navigator = global.window.navigator;
+  env.elements['user-email'].value = 'me@example.com';
+  env.elements['user-mail-btn'].events.click({ preventDefault(){} });
+  assert.ok(opened.includes('mail.google.com'));
+});
+
+test('user reddit link opens compose url', async () => {
+  const env = setupEnv();
+  const mod = await loadModule();
+  await mod.initLogin();
+  let opened = '';
+  global.window.open = (url) => { opened = url; };
+  env.elements['user-email'].value = 'me@example.com';
+  env.elements['user-reddit-link'].events.click({ preventDefault(){} });
+  assert.ok(opened.includes('reddit.com/message/compose'));
 });


### PR DESCRIPTION
## Summary
- broaden `makeEl` to capture element event handlers
- add many login-ui tests covering role switching, login workflows and contact links

## Testing
- `node --test web/test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6853996cf9e0832faecf55ecd04acf91