### PR TITLE
Increase products UI test coverage

### DIFF
--- a/tests/test_check_stock.py
+++ b/tests/test_check_stock.py
@@ -5,7 +5,22 @@ import sys
 import types
 
 # Import aiohttp for mocking
-import aiohttp
+try:
+    import aiohttp
+except ImportError:  # pragma: no cover - fallback for environments without aiohttp
+    class ClientError(Exception):
+        pass
+
+    class ClientResponseError(Exception):
+        def __init__(self, *, request_info=None, history=None, status=None, message=""):
+            super().__init__(message)
+            self.request_info = request_info
+            self.history = history
+            self.status = status
+            self.message = message
+
+    aiohttp = types.SimpleNamespace(ClientError=ClientError, ClientResponseError=ClientResponseError)
+    sys.modules.setdefault("aiohttp", aiohttp)
 
 # Provide dummy modules for optional dependencies
 # sys.modules.setdefault("aiohttp", types.ModuleType("aiohttp")) # Keep real aiohttp for ClientError


### PR DESCRIPTION
## Summary
- add stub for `aiohttp` so tests run without dependency
- extend `products-ui` tests to cover deletion, editing, and fetchAPI fallback

## Testing
- `pytest -q`
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_685399c85490832fa2994948bcad541f