### PR TITLE
Add basic fuzzing harness

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,27 @@
+name: Fuzzing
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install atheris
+      - name: Run fuzzing
+        run: |
+          python fuzz/fuzz_notifications.py -runs=100

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ This project is open-source and available under the **MIT License**. That means 
 
 * [Project structure](StructureReadMe.md) 🗂️
 * [Todo & roadmap](ToDoReadMe.md) ✅
+* [Fuzzing harness](fuzz/README.md) 🐛
 
 ## References
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,14 @@
+# Fuzzing
+
+This folder contains fuzzing targets for the project.
+
+Currently it includes a Python fuzzer for the email formatting utilities in `scripts/notifications.py` built using [Atheris](https://github.com/google/atheris).
+
+To run the fuzzer locally:
+
+```bash
+pip install atheris
+python fuzz/fuzz_notifications.py -runs=100
+```
+
+The accompanying GitHub Actions workflow `fuzz.yml` executes this fuzzer on every pull request.

--- a/fuzz/fuzz_notifications.py
+++ b/fuzz/fuzz_notifications.py
@@ -1,0 +1,18 @@
+import atheris
+import sys
+
+with atheris.instrument_imports():
+    from scripts import notifications
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    product_name = fdp.ConsumeUnicodeNoSurrogates(50)
+    url = fdp.ConsumeUnicodeNoSurrogates(100)
+    notifications.format_long_message(product_name, url)
+    notifications.format_short_message(product_name)
+
+
+after_setup = atheris.Setup
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()


### PR DESCRIPTION
## Summary
- create a simple fuzz target for `notifications` using Atheris
- run the fuzzer in a new GitHub Actions workflow
- document fuzzing in the README

## Testing
- `pytest -q`
- `npm --prefix web test` *(fails: `c8` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853aa442c7c832fb02e00a74a833762