### PR TITLE
Fix Scorecard token permissions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- limit default token scope in python tests workflow

## Testing
- `pytest -q` *(fails: Could not install packages due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6853aa3761f0832f852205fb18923d71