### PR TITLE
Fix CodeQL warnings and tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
   branch_protection_rule:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/web/components/products-ui/products-ui.js
+++ b/web/components/products-ui/products-ui.js
@@ -19,13 +19,13 @@ function displayError(elementId, message, timeout = 5000) {
     clearTimeout(errorTimers[elementId]);
   }
 
-  errorElement.innerHTML = message;
+  errorElement.textContent = message;
   errorElement.classList.add('alert', 'alert-danger');
   errorElement.style.display = 'block'; // Ensure it's visible
 
   // Set new timeout
   errorTimers[elementId] = setTimeout(() => {
-    errorElement.innerHTML = '';
+    errorElement.textContent = '';
     errorElement.classList.remove('alert', 'alert-danger');
     errorElement.style.display = 'none'; // Hide it again
     delete errorTimers[elementId]; // Remove timer ID once done
@@ -40,7 +40,7 @@ function clearError(elementId) {
     clearTimeout(errorTimers[elementId]);
     delete errorTimers[elementId];
   }
-  errorElement.innerHTML = '';
+  errorElement.textContent = '';
   errorElement.classList.remove('alert', 'alert-danger');
   errorElement.style.display = 'none'; // Ensure it's hidden
 }

--- a/web/test/login-ui.test.js
+++ b/web/test/login-ui.test.js
@@ -170,7 +170,8 @@ test('user mail button opens gmail on desktop', async () => {
   global.navigator = global.window.navigator;
   env.elements['user-email'].value = 'me@example.com';
   env.elements['user-mail-btn'].events.click({ preventDefault(){} });
-  assert.ok(opened.includes('mail.google.com'));
+  const mailUrl = new URL(opened);
+  assert.equal(mailUrl.hostname, 'mail.google.com');
 });
 
 test('user reddit link opens compose url', async () => {
@@ -181,5 +182,7 @@ test('user reddit link opens compose url', async () => {
   global.window.open = (url) => { opened = url; };
   env.elements['user-email'].value = 'me@example.com';
   env.elements['user-reddit-link'].events.click({ preventDefault(){} });
-  assert.ok(opened.includes('reddit.com/message/compose'));
+  const redditUrl = new URL(opened);
+  assert.equal(redditUrl.hostname, 'www.reddit.com');
+  assert.ok(redditUrl.pathname.startsWith('/message/compose'));
 });

--- a/web/test/products-ui.test.js
+++ b/web/test/products-ui.test.js
@@ -116,7 +116,7 @@ test('handleAddProduct shows error for missing fields', async () => {
   env.elements['product-name'].value = '';
   env.elements['product-url'].value = '';
   await trigger(env.elements['add-product-btn'], 'click', { preventDefault(){} });
-  assert.equal(env.elements['add-product-error-message'].innerHTML, 'Please enter both product name and URL.');
+  assert.equal(env.elements['add-product-error-message'].textContent, 'Please enter both product name and URL.');
 });
 
 test('renderProductsList creates list items', async () => {


### PR DESCRIPTION
## Summary
- avoid innerHTML when displaying product errors
- check URLs by parsing in login UI tests
- adjust tests for new error message fields
- set top-level `contents: read` permissions for workflows

## Testing
- `pytest`
- `npm --prefix web test` *(fails: c8 not found)*
- `pip install -r requirements.txt` *(fails: ProxyError)*
- `npm install --prefix web` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6853c5d0e658832f9aa4c4ff816ec8b1