### PR TITLE
Fix actions/cache deprecation

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -23,7 +23,7 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Cache Playwright browsers
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@v4
         with:
           path: pw-browsers
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/requirements.txt') }}


### PR DESCRIPTION
## Summary
- update the Playwright browser cache step to use `actions/cache@v4`

## Testing
- `pytest -q`
- `npm --prefix web test --silent` *(fails: `c8` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685434a0462c832f8aed76e1b9f93cb8