### PR TITLE
Add clear userEmail on admin back

### DIFF
--- a/web/components/user-main/user.html
+++ b/web/components/user-main/user.html
@@ -152,6 +152,14 @@
         window.location.href = '../../index.html';
       });
 
+      const backBtn = document.getElementById('back-to-admin-btn');
+      if (backBtn) {
+        backBtn.addEventListener('click', () => {
+          localStorage.removeItem('userEmail');
+          window.location.href = '../admin-main/admin.html';
+        });
+      }
+
       initParticles();
       initIcons();
       initBackground();


### PR DESCRIPTION
## Summary
- update user page logic to clear stored userEmail when navigating back to admin panel

## Testing
- `pytest -q` *(fails: async tests require plugins)*
- `node tests/js/login.test.mjs`
- `node tests/js/utils.test.mjs`
- `node tests/js/subscription-modal.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_685d1f2009e0832fa5bb8e2841d356d3