### PR TITLE
Replace Quill editor with textarea

### DIFF
--- a/web/components/admin-main/admin-main.js
+++ b/web/components/admin-main/admin-main.js
@@ -4,6 +4,7 @@ import {initParticles} from '../particles-config/particles-config.js';
 import {initIcons} from '../icons/icons.js';
 import {initRecipientsUI} from '../recipients-ui/recipients-ui.js';
 import {initProductsUI} from '../products-ui/products-ui.js';
+import { escapeHTML } from '../utils/utils.js';
 import '../subscription/subscriptions-ui.js';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -120,7 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (htmlEditor && htmlPreview) {
       const updatePreview = () => {
-        htmlPreview.innerHTML = htmlEditor.value;
+        htmlPreview.innerHTML = escapeHTML(htmlEditor.value || '');
       };
       htmlEditor.addEventListener('input', updatePreview);
       document.getElementById('preview-tab')?.addEventListener('shown.bs.tab', updatePreview);
@@ -151,8 +152,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const subject = emailBlastSubject.value.trim();
         const recipientType = document.querySelector('input[name="recipientType"]:checked').value;
 
-        const htmlBody = htmlEditor.value.trim();
-        const plainBody = htmlBody.replace(/<[^>]+>/g, '').trim();
+        const htmlBody = escapeHTML(htmlEditor.value.trim());
+        const doc = new DOMParser().parseFromString(htmlBody, 'text/html');
+        const plainBody = (doc.body.textContent || '').trim();
 
         if (!subject) {
           emailBlastStatus.innerHTML = '<div class="alert alert-danger">Subject is required.</div>';

--- a/web/components/admin-main/admin-main.js
+++ b/web/components/admin-main/admin-main.js
@@ -44,7 +44,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // Email Blast Modal & Editor Initialization
   const emailBlastModalElement = document.getElementById('emailBlastModal');
   const emailBlastBtn = document.getElementById('email-blast-btn');
-  let quillEditor;
 
   if (emailBlastModalElement && emailBlastBtn) {
     const emailBlastModal = new bootstrap.Modal(emailBlastModalElement);
@@ -53,28 +52,12 @@ document.addEventListener('DOMContentLoaded', () => {
       emailBlastModal.show();
     });
 
-    // Initialize Quill editor
-    // Doing it here to ensure it's ready when modal is shown,
-    // but could also be done on modal 'shown.bs.modal' event if preferred.
-    quillEditor = new Quill('#html-editor-container', {
-      theme: 'snow', // 'snow' is a common theme with a toolbar
-      modules: {
-        toolbar: [
-          [{ 'header': [1, 2, 3, false] }],
-          ['bold', 'italic', 'underline', 'strike'],
-          [{ 'list': 'ordered'}, { 'list': 'bullet' }],
-          [{ 'color': [] }, { 'background': [] }],
-          ['link'],
-          ['clean']
-        ]
-      }
-    });
 
     const sendEmailBlastBtn = document.getElementById('send-email-blast-btn');
     const emailBlastSubject = document.getElementById('email-blast-subject');
-    const plainTextEditor = document.getElementById('plain-text-editor');
+    const htmlEditor = document.getElementById('html-editor');
+    const htmlPreview = document.getElementById('html-preview');
     const emailBlastStatus = document.getElementById('email-blast-status');
-    const htmlEditorTab = document.getElementById('html-editor-tab');
     const recipientInput = document.getElementById('recipient-input');
     const recipientList = document.getElementById('recipient-list');
     let extraRecipients = [];
@@ -135,6 +118,12 @@ document.addEventListener('DOMContentLoaded', () => {
       renderRecipients();
     };
 
+    if (htmlEditor && htmlPreview) {
+      htmlEditor.addEventListener('input', () => {
+        htmlPreview.innerHTML = htmlEditor.value;
+      });
+    }
+
     if (recipientInput && recipientList) {
       document.querySelectorAll('input[name="recipientType"]').forEach(r => {
         r.addEventListener('change', updateBaseRecipients);
@@ -154,25 +143,13 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
 
-    if (sendEmailBlastBtn && emailBlastSubject && plainTextEditor && emailBlastStatus && htmlEditorTab) {
+    if (sendEmailBlastBtn && emailBlastSubject && htmlEditor && emailBlastStatus) {
       sendEmailBlastBtn.addEventListener('click', async () => {
         const subject = emailBlastSubject.value.trim();
         const recipientType = document.querySelector('input[name="recipientType"]:checked').value;
 
-        let htmlBody = '';
-        let plainBody = '';
-
-        if (htmlEditorTab.classList.contains('active')) {
-          htmlBody = quillEditor.root.innerHTML; // Get HTML content from Quill
-          // A simple way to get plain text from Quill's HTML, or use quill.getText()
-          // For now, let's assume if HTML is active, plainBody might be derived or empty if not explicitly provided.
-          // For simplicity, if HTML is active, we'll primarily send HTML.
-          // The API will need to handle if only one format is provided.
-          plainBody = quillEditor.getText(); // Get plain text version from Quill
-        } else {
-          plainBody = plainTextEditor.value.trim();
-          // If plain text is active, HTML body will be empty or derived by server if needed.
-        }
+        const htmlBody = htmlEditor.value.trim();
+        const plainBody = htmlBody.replace(/<[^>]+>/g, '').trim();
 
         if (!subject) {
           emailBlastStatus.innerHTML = '<div class="alert alert-danger">Subject is required.</div>';
@@ -210,8 +187,8 @@ document.addEventListener('DOMContentLoaded', () => {
             emailBlastStatus.innerHTML = `<div class="alert alert-success">${result.message}</div>`;
             // Optionally close modal or clear form here
             // emailBlastSubject.value = '';
-            // quillEditor.setText('');
-            // plainTextEditor.value = '';
+            // htmlEditor.value = '';
+            // htmlPreview.innerHTML = '';
           } else {
             emailBlastStatus.innerHTML = `<div class="alert alert-danger">Error: ${result.message || 'Failed to send emails.'}</div>`;
           }

--- a/web/components/admin-main/admin-main.js
+++ b/web/components/admin-main/admin-main.js
@@ -119,9 +119,12 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     if (htmlEditor && htmlPreview) {
-      htmlEditor.addEventListener('input', () => {
+      const updatePreview = () => {
         htmlPreview.innerHTML = htmlEditor.value;
-      });
+      };
+      htmlEditor.addEventListener('input', updatePreview);
+      document.getElementById('preview-tab')?.addEventListener('shown.bs.tab', updatePreview);
+      updatePreview();
     }
 
     if (recipientInput && recipientList) {

--- a/web/components/admin-main/admin.html
+++ b/web/components/admin-main/admin.html
@@ -6,7 +6,6 @@
   <title>Amul Watchdog Control</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/quill@2.0.0-rc.2/dist/quill.snow.css" rel="stylesheet">
   <link rel="stylesheet" href="../../style.css">
 </head>
 <body>
@@ -160,22 +159,8 @@
               <input type="text" class="form-control" id="email-blast-subject" required>
             </div>
 
-            <ul class="nav nav-tabs mb-3" id="emailEditorTabs" role="tablist">
-              <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="html-editor-tab" data-bs-toggle="tab" data-bs-target="#html-editor-pane" type="button" role="tab" aria-controls="html-editor-pane" aria-selected="true">HTML Editor</button>
-              </li>
-              <li class="nav-item" role="presentation">
-                <button class="nav-link" id="plain-text-editor-tab" data-bs-toggle="tab" data-bs-target="#plain-text-editor-pane" type="button" role="tab" aria-controls="plain-text-editor-pane" aria-selected="false">Plain Text</button>
-              </li>
-            </ul>
-            <div class="tab-content" id="emailEditorTabContent">
-              <div class="tab-pane fade show active" id="html-editor-pane" role="tabpanel" aria-labelledby="html-editor-tab">
-                <div id="html-editor-container" style="height: 250px;"></div>
-              </div>
-              <div class="tab-pane fade" id="plain-text-editor-pane" role="tabpanel" aria-labelledby="plain-text-editor-tab">
-                <textarea class="form-control" id="plain-text-editor" rows="10"></textarea>
-              </div>
-            </div>
+            <textarea class="form-control" id="html-editor" rows="10"></textarea>
+            <div id="html-preview" class="border p-2 mt-2" style="min-height: 150px;"></div>
 
             <h6 class="mt-4">Recipients</h6>
             <div class="form-check">
@@ -238,7 +223,6 @@
 
   <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.0/dist/jszip.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/quill@2.0.0-rc.2/dist/quill.js"></script>
   <script src="../../particles.js"></script>
   <script src="../../vanilla-tilt.min.js"></script>
   <script src="../../lucide-icons.js"></script>

--- a/web/components/admin-main/admin.html
+++ b/web/components/admin-main/admin.html
@@ -159,8 +159,22 @@
               <input type="text" class="form-control" id="email-blast-subject" required>
             </div>
 
-            <textarea class="form-control" id="html-editor" rows="10"></textarea>
-            <div id="html-preview" class="border p-2 mt-2" style="min-height: 150px;"></div>
+            <ul class="nav nav-tabs mb-3" id="emailEditorTabs" role="tablist">
+              <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="html-editor-tab" data-bs-toggle="tab" data-bs-target="#html-editor-pane" type="button" role="tab" aria-controls="html-editor-pane" aria-selected="true">Edit</button>
+              </li>
+              <li class="nav-item" role="presentation">
+                <button class="nav-link" id="preview-tab" data-bs-toggle="tab" data-bs-target="#preview-pane" type="button" role="tab" aria-controls="preview-pane" aria-selected="false">Preview</button>
+              </li>
+            </ul>
+            <div class="tab-content" id="emailEditorTabContent">
+              <div class="tab-pane fade show active" id="html-editor-pane" role="tabpanel" aria-labelledby="html-editor-tab">
+                <textarea class="form-control" id="html-editor" rows="10"></textarea>
+              </div>
+              <div class="tab-pane fade" id="preview-pane" role="tabpanel" aria-labelledby="preview-tab">
+                <div id="html-preview" class="border p-2" style="min-height: 250px;"></div>
+              </div>
+            </div>
 
             <h6 class="mt-4">Recipients</h6>
             <div class="form-check">

--- a/web/test/admin-main.test.js
+++ b/web/test/admin-main.test.js
@@ -15,7 +15,7 @@ function makeEl() {
 
 test('handler redirects to index when no token', async () => {
   const events = {};
-  const elements = { loader: makeEl(), status: makeEl() };
+  const elements = { loader: makeEl(), status: makeEl(), 'html-editor': makeEl(), 'html-preview': makeEl() };
   global.document = {
     addEventListener: (ev, cb) => events[ev] = cb,
     getElementById: id => elements[id] || makeEl(),
@@ -27,7 +27,6 @@ test('handler redirects to index when no token', async () => {
   global.window = { location: { href: '' }, addEventListener(){}, innerHeight:0 };
   global.localStorage = { getItem: () => null };
   global.bootstrap = { Modal: function(){ return { show(){} }; }, Tooltip: function(){} };
-  global.Quill = function(){ this.root = { innerHTML: '' }; this.getText = () => ''; };
   global.window.fetchAPI = async () => [];
 
   await import('../components/admin-main/admin-main.js?' + Date.now());
@@ -54,7 +53,7 @@ function makeEventEl(){
 test('initializes logout handler when token present', async () => {
   const events = {};
   const logoutBtn = makeEventEl();
-  const elements = { loader: makeEventEl(), status: makeEventEl(), 'logout-btn': logoutBtn };
+  const elements = { loader: makeEventEl(), status: makeEventEl(), 'logout-btn': logoutBtn, 'html-editor': makeEventEl(), 'html-preview': makeEventEl() };
   global.document = {
     addEventListener: (ev, cb) => events[ev] = cb,
     getElementById: id => elements[id] || makeEventEl(),
@@ -68,7 +67,6 @@ test('initializes logout handler when token present', async () => {
   global.localStorage = { getItem: () => 'tok', removeItem: () => { removedToken = true; } };
   global.particlesJS = () => {};
   global.bootstrap = { Tooltip: function(){}, Modal: function(){ return { show(){} }; } };
-  global.Quill = function(){ this.root = { innerHTML: '' }; this.getText = () => ''; };
   global.lucide = { createIcons(){} };
   global.VanillaTilt = { init(){} };
   global.window.fetchAPI = async () => [];


### PR DESCRIPTION
## Summary
- refactor admin HTML editor and preview
- update admin JS to use plain textarea
- adjust admin tests for new HTML editor

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d5095cd90832f82e329db996d6ca8