### PR TITLE
Fix HTML preview for email blast

### DIFF
--- a/web/components/admin-main/admin-main.js
+++ b/web/components/admin-main/admin-main.js
@@ -4,7 +4,6 @@ import {initParticles} from '../particles-config/particles-config.js';
 import {initIcons} from '../icons/icons.js';
 import {initRecipientsUI} from '../recipients-ui/recipients-ui.js';
 import {initProductsUI} from '../products-ui/products-ui.js';
-import { escapeHTML } from '../utils/utils.js';
 import '../subscription/subscriptions-ui.js';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -121,7 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (htmlEditor && htmlPreview) {
       const updatePreview = () => {
-        htmlPreview.innerHTML = escapeHTML(htmlEditor.value || '');
+        htmlPreview.innerHTML = htmlEditor.value || '';
       };
       htmlEditor.addEventListener('input', updatePreview);
       document.getElementById('preview-tab')?.addEventListener('shown.bs.tab', updatePreview);
@@ -152,7 +151,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const subject = emailBlastSubject.value.trim();
         const recipientType = document.querySelector('input[name="recipientType"]:checked').value;
 
-        const htmlBody = escapeHTML(htmlEditor.value.trim());
+        const htmlBody = htmlEditor.value.trim();
         const doc = new DOMParser().parseFromString(htmlBody, 'text/html');
         const plainBody = (doc.body.textContent || '').trim();
 


### PR DESCRIPTION
## Summary
- show real HTML in admin email blast preview
- send unescaped HTML for blast emails

## Testing
- `pytest -q` *(fails: async functions not natively supported)*
- `npm test --silent` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6805a890832f8177aa4b75e33a22