### PR TITLE
Fix admin removed from self blasts

### DIFF
--- a/web/components/admin-main/admin-main.js
+++ b/web/components/admin-main/admin-main.js
@@ -169,6 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         try {
           const token = localStorage.getItem('authToken');
+          const recipients = [...new Set([...baseRecipients, ...extraRecipients])];
           const response = await fetch('/api/email-blast', {
             method: 'POST',
             headers: {
@@ -181,7 +182,7 @@ document.addEventListener('DOMContentLoaded', () => {
               plainBody,
               recipientType,
               adminEmail: localStorage.getItem('adminEmail'), // For "self" recipient type
-              extraRecipients
+              recipients
             })
           });
 


### PR DESCRIPTION
## Summary
- allow custom recipient list when sending email blasts
- send deduped list of recipients to the API
- respect provided recipient list on the server

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q` *(fails: async functions not supported)*

------
https://chatgpt.com/codex/tasks/task_e_685e15af2510832fb04b6aaa5518b94f