### PR TITLE
Make help FAB and 'How to use' button user-mode specific

### DIFF
--- a/web/components/admin-main/admin.html
+++ b/web/components/admin-main/admin.html
@@ -126,7 +126,8 @@
     </div> <!-- End of main row -->
   </div> <!-- End of container -->
   </div> <!-- End of main-app-content -->
-  <button type="button" class="fab" data-bs-toggle="offcanvas" data-bs-target="#settingsPane" aria-controls="settingsPane" aria-label="Open Settings">
+
+  <button type="button" class="fab" id="settings-fab" data-bs-toggle="offcanvas" data-bs-target="#settingsPane" aria-controls="settingsPane" aria-label="Open Settings">
     <i data-lucide="sliders"></i>
   </button>
 

--- a/web/components/user-main/user.html
+++ b/web/components/user-main/user.html
@@ -26,7 +26,13 @@
     <p id="welcome-msg" class="mb-4 fw-bold initial"></p>
     <div id="user-subscriptions-container"></div>
   </div>
-  <button type="button" class="fab" data-bs-toggle="offcanvas" data-bs-target="#settingsPane" aria-controls="settingsPane" aria-label="Open Settings">
+
+  <!-- New Help FAB -->
+  <button type="button" class="fab" id="help-fab" aria-label="Help">
+    <i data-lucide="help-circle"></i>
+  </button>
+
+  <button type="button" class="fab" id="user-settings-fab" data-bs-toggle="offcanvas" data-bs-target="#settingsPane" aria-controls="settingsPane" aria-label="Open Settings">
     <i data-lucide="sliders"></i>
   </button>
 
@@ -36,6 +42,8 @@
       <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body">
+      <button type="button" id="user-how-to-use-btn" class="btn btn-success w-100 mb-3"><i data-lucide="help-circle" class="me-1"></i>How to use the app</button>
+      <hr class="mb-4">
       <div class="mb-4">
         <h6 class="mb-2">Account</h6>
         <button type="button" id="change-username-btn" class="btn btn-primary w-100 mb-2"><i data-lucide="user" class="me-1"></i>Change Display Name</button>
@@ -68,6 +76,25 @@
       </div>
     </div>
   </div>
+
+  <!-- Under Development Modal -->
+  <div class="modal fade" id="underDevelopmentModal" tabindex="-1" aria-labelledby="underDevelopmentModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="underDevelopmentModalLabel">Information</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p>This feature is currently under development. Please check back later!</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="../../particles.js"></script>
   <script src="../../lucide-icons.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
@@ -188,6 +215,59 @@
         console.error('Failed to load subscription UI', e);
       }
       await initUserSubscriptionsUI();
+
+      // Help FAB and Modal Initialization
+      const helpFab = document.getElementById('help-fab');
+      const underDevelopmentModalElement = document.getElementById('underDevelopmentModal');
+      const userHowToUseBtn = document.getElementById('user-how-to-use-btn'); // Get the new button
+      let underDevelopmentModal;
+
+      if (underDevelopmentModalElement) {
+        underDevelopmentModal = new bootstrap.Modal(underDevelopmentModalElement);
+      }
+
+      // Logic for the "How to use the app" button in user settings
+      if (userHowToUseBtn && underDevelopmentModal) {
+        userHowToUseBtn.addEventListener('click', () => {
+          const settingsPaneElement = document.getElementById('settingsPane');
+          if (settingsPaneElement && settingsPaneElement.classList.contains('show')) {
+              const settingsOffcanvas = bootstrap.Offcanvas.getInstance(settingsPaneElement);
+              if (settingsOffcanvas) {
+                  settingsOffcanvas.hide();
+              }
+          }
+          // Ensure modal is shown after offcanvas starts closing
+          setTimeout(() => {
+              underDevelopmentModal.show();
+          }, 150);
+        });
+      }
+
+      if (helpFab && underDevelopmentModal) { // Ensure both elements exist
+        helpFab.classList.add('active-glow'); // Start glowing
+
+        helpFab.addEventListener('click', () => {
+          underDevelopmentModal.show();
+        });
+
+        const helpFabModalCloseListener = () => {
+          if (helpFab.style.display !== 'none') {
+              helpFab.classList.remove('active-glow');
+              helpFab.style.display = 'none';
+          }
+          underDevelopmentModalElement.removeEventListener('hidden.bs.modal', helpFabModalCloseListener);
+        };
+
+        // Add listener for when the modal is shown
+        underDevelopmentModalElement.addEventListener('shown.bs.modal', () => {
+          // Check if the FAB is visible and glowing (implying it was the trigger)
+          if (helpFab.style.display !== 'none' && helpFab.classList.contains('active-glow')) {
+            // Add the specific close listener for the FAB
+            underDevelopmentModalElement.addEventListener('hidden.bs.modal', helpFabModalCloseListener);
+          }
+        });
+      }
+
       hideGlobalLoader();
       const gmailLink = document.getElementById('feedbackGmail');
       const to = 'linktracker03@gmail.com';

--- a/web/style.css
+++ b/web/style.css
@@ -263,6 +263,55 @@ button, .btn {
       transition: background-color 0.2s ease-out, box-shadow 0.2s ease-out;
     }
 
+#settings-fab {
+  /* Standard FAB styling is already applied by .fab */
+  /* Specific adjustments if needed, but for now it's the base */
+}
+
+#help-fab {
+  position: fixed;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  z-index: 1051; /* Slightly above settings FAB if they were to overlap */
+  transition: background-color 0.2s ease-out, box-shadow 0.2s ease-out, opacity 0.3s ease-out;
+  right: 20px;
+  bottom: 90px; /* Position above the settings FAB (56px height + 20px bottom + 14px spacing) */
+  background-color: #ffc107; /* A distinct yellow/orange color */
+  color: #212529; /* Darker text for contrast on yellow */
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+}
+
+#help-fab:hover {
+  background-color: #e0a800; /* Darker yellow on hover */
+  box-shadow: 0 6px 12px rgba(0,0,0,0.3);
+}
+
+#help-fab i,
+#help-fab svg {
+  width: 28px; /* Slightly larger icon */
+  height: 28px;
+}
+
+/* Glowing/Shimmering Animation for Help FAB */
+@keyframes helpFabGlow {
+  0%, 100% {
+    box-shadow: 0 0 8px rgba(255, 193, 7, 0.7), 0 0 12px rgba(255, 193, 7, 0.5), 0 4px 8px rgba(0,0,0,0.2);
+  }
+  50% {
+    box-shadow: 0 0 16px rgba(255, 193, 7, 1), 0 0 24px rgba(255, 193, 7, 0.7), 0 6px 12px rgba(0,0,0,0.3);
+  }
+}
+
+#help-fab.active-glow { /* Class to toggle animation */
+  animation: helpFabGlow 1.5s infinite ease-in-out;
+}
+
+
 /* --------------- NEW UI SECTIONS STYLING --------------- */
 
 /* General Card Styling for new sections */


### PR DESCRIPTION
- Moved the new help FAB HTML and its associated 'Under Development' modal from admin files to user files (`web/components/user-main/user.html`).
- Moved the JavaScript logic for the help FAB (glow, click to open modal, disappearance on close) to the embedded script in `user.html`.
- Removed the 'How to use the app' button and its JS from the admin settings panel.
- Added the 'How to use the app' button to the user settings panel in `user.html` and implemented its JS logic to open the modal.
- CSS for the help FAB remains in `web/style.css` and applies correctly in user mode.

This ensures the attention-seeking help FAB is only visible and functional in the user mode, not in admin mode.