### PR TITLE
Fix session closed error when updating stock counters

### DIFF
--- a/scripts/check_stock.py
+++ b/scripts/check_stock.py
@@ -274,8 +274,9 @@ async def main():
 
         await browser.close()
 
-    print("\nStock check finished.")
-    await save_stock_counters(session, stock_counters)
+        print("\nStock check finished.")
+        await save_stock_counters(session, stock_counters)
+
 
     run_timestamp_utc = datetime.now(timezone.utc)
     ist_offset = timedelta(hours=5, minutes=30)


### PR DESCRIPTION
## Summary
- ensure the stock counter update runs before closing the aiohttp session

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68640c3c7578832faed13e70526013c9