### PR TITLE
Add toast and loader when saving pincode

### DIFF
--- a/web/components/user-main/user.html
+++ b/web/components/user-main/user.html
@@ -218,11 +218,12 @@
             });
             localStorage.setItem(`pincode_${email}`, pin);
             const offcanvasEl = document.getElementById('settingsPane');
-            const off = offcanvasEl ? bootstrap.Offcanvas.getInstance(offcanvasEl) : null;
+            const off = offcanvasEl ? bootstrap.Offcanvas.getOrCreateInstance(offcanvasEl) : null;
             if (off) off.hide();
-            showToastNotification('Pincode saved', 'success');
+            showToastNotification('Pincode saved successfully.', 'success');
           } catch (e) {
             console.error('Failed to save pincode', e);
+            showToastNotification('Failed to save pincode.', 'error');
           } finally {
             hideGlobalLoader();
           }

--- a/web/components/user-main/user.html
+++ b/web/components/user-main/user.html
@@ -82,6 +82,7 @@
     import { initBackground } from "../ui/ui.js";
     import { initUserSubscriptionsUI } from "../user-subscriptions/user-subscriptions.js";
     import { showGlobalLoader, hideGlobalLoader, escapeHTML, fetchAPI } from "../utils/utils.js";
+    import { showToastNotification } from "../subscription/subscription-helpers.js";
 
     document.addEventListener("DOMContentLoaded", async () => {
       showGlobalLoader();
@@ -208,6 +209,7 @@
           }
           const rid = localStorage.getItem(`recipientId_${email}`);
           if (!rid) return;
+          showGlobalLoader();
           try {
             await fetchAPI(`/api/recipients?id=${rid}`, {
               method: 'PUT',
@@ -215,8 +217,14 @@
               body: JSON.stringify({ pincode: pin })
             });
             localStorage.setItem(`pincode_${email}`, pin);
+            const offcanvasEl = document.getElementById('settingsPane');
+            const off = offcanvasEl ? bootstrap.Offcanvas.getInstance(offcanvasEl) : null;
+            if (off) off.hide();
+            showToastNotification('Pincode saved', 'success');
           } catch (e) {
             console.error('Failed to save pincode', e);
+          } finally {
+            hideGlobalLoader();
           }
         });
       }


### PR DESCRIPTION
## Summary
- show toast notifications and close settings on pincode save

## Testing
- `npm test --prefix web` *(fails: c8 not found)*
- `pytest -q` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865f555f9f4832f82255f2cfb714a80