### PR TITLE
Fix stock streak calculation

### DIFF
--- a/scripts/check_stock.py
+++ b/scripts/check_stock.py
@@ -107,7 +107,13 @@ async def load_stock_counters(session):
     )
     data = await fetch_api_data(session, url, headers=headers)
     if isinstance(data, dict):
-        return data
+        converted = {}
+        for key, val in data.items():
+            if isinstance(key, str) and key.isdigit():
+                converted[int(key)] = val
+            else:
+                converted[key] = val
+        return converted
     return {}
 
 

--- a/tests/test_check_stock.py
+++ b/tests/test_check_stock.py
@@ -229,6 +229,18 @@ async def test_save_stock_counters_with_admin_token(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_load_stock_counters_key_conversion(monkeypatch):
+    """Keys returned from API should be converted to integers if possible."""
+    async def mock_fetch(session, url, headers=None):
+        return {"1": 5, "2": 3}
+
+    monkeypatch.setattr(check_stock, "fetch_api_data", mock_fetch)
+    counters = await check_stock.load_stock_counters(None)
+    assert counters == {1: 5, 2: 3}
+    assert all(isinstance(k, int) for k in counters.keys())
+
+
+@pytest.mark.asyncio
 async def test_process_product_fetch_subscriptions_none(monkeypatch):
     """Test process_product when fetch_subscriptions returns None."""
     product_info = {"id": 1, "name": "Test Product", "url": "http://example.com"}


### PR DESCRIPTION
## Summary
- convert stock counter keys to integers when loading
- test for key conversion in `load_stock_counters`

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6865ff17cc44832f8967e0a211a282b9