### PR TITLE
Display user pincode in subscription modal

### DIFF
--- a/web/components/recipients-ui/recipients-ui.js
+++ b/web/components/recipients-ui/recipients-ui.js
@@ -86,6 +86,9 @@ function renderRecipientsList(recipients) {
     listItem.className = 'list-group-item d-flex justify-content-between align-items-center';
     listItem.setAttribute('data-recipient-id', recipient.id);
     listItem.setAttribute('data-recipient-email', recipient.email);
+    if (recipient.pincode) {
+      listItem.setAttribute('data-recipient-pincode', recipient.pincode);
+    }
 
     const emailSpan = document.createElement('span');
     emailSpan.textContent = recipient.email;
@@ -101,6 +104,9 @@ function renderRecipientsList(recipients) {
     manageBtn.title = 'Manage Subscriptions'; // Add title for accessibility
     manageBtn.setAttribute('data-recipient-id', recipient.id);
     manageBtn.setAttribute('data-recipient-email', recipient.email);
+    if (recipient.pincode) {
+      manageBtn.setAttribute('data-recipient-pincode', recipient.pincode);
+    }
 
 
     const deleteBtn = document.createElement('button');
@@ -195,17 +201,17 @@ async function handleDeleteRecipient(recipientId) {
 }
 
 // Handles showing the manage subscriptions section for a recipient
-function handleManageSubscriptions(recipientId, recipientEmail) {
+function handleManageSubscriptions(recipientId, recipientEmail, recipientPincode) {
   if (!recipientId || !recipientEmail) {
     console.error('Recipient ID or email not provided for managing subscriptions.');
     return;
   }
 
-  window.selectedRecipient = { id: recipientId, email: recipientEmail };
+  window.selectedRecipient = { id: recipientId, email: recipientEmail, pincode: recipientPincode };
 
   // Notify subscriptions-ui.js to open its modal
   if (window.openSubscriptionModal) {
-    window.openSubscriptionModal(recipientId, recipientEmail);
+    window.openSubscriptionModal(recipientId, recipientEmail, recipientPincode);
   } else {
     console.warn('openSubscriptionModal function not found on window. Subscriptions UI cannot be opened.');
     alert('Subscription management UI is currently unavailable.');
@@ -241,14 +247,16 @@ export function initRecipientsUI() {
 
       if (!target) return;
 
-      const recipientId = target.closest('li[data-recipient-id]')?.dataset.recipientId;
-      const recipientEmail = target.closest('li[data-recipient-id]')?.dataset.recipientEmail;
+      const recipientLi = target.closest('li[data-recipient-id]');
+      const recipientId = recipientLi?.dataset.recipientId;
+      const recipientEmail = recipientLi?.dataset.recipientEmail;
+      const recipientPincode = recipientLi?.dataset.recipientPincode;
 
 
       if (target.classList.contains('delete-recipient-btn')) {
         if (recipientId) handleDeleteRecipient(recipientId);
       } else if (target.classList.contains('manage-subscriptions-btn')) { // Only button triggers
-         if (recipientId && recipientEmail) handleManageSubscriptions(recipientId, recipientEmail);
+         if (recipientId && recipientEmail) handleManageSubscriptions(recipientId, recipientEmail, recipientPincode);
       }
     });
   }

--- a/web/components/subscription/subscription-modal.js
+++ b/web/components/subscription/subscription-modal.js
@@ -252,10 +252,11 @@ async function _loadSubscriptionsForRecipientAndRenderIntoModal(recipientId, mod
   renderSubscriptionProductsInModal(allProducts, recipientSubscriptions || [], recipientId, modalBodyElement);
 }
 
-export async function openSubscriptionModal(recipientId, recipientName) {
+export async function openSubscriptionModal(recipientId, recipientName, recipientPincode) {
   currentModalRecipientId = recipientId;
   const modal = document.getElementById('subscriptionModal');
   const modalTitle = document.getElementById('subscriptionModalHeaderTitle');
+  const pincodeEl = document.getElementById('subscriptionModalPincode');
   const modalBody = document.getElementById('subscriptionModalBody');
   if (!modal || !modalTitle || !modalBody) {
     console.error('Subscription modal elements not found in DOM.');
@@ -263,6 +264,9 @@ export async function openSubscriptionModal(recipientId, recipientName) {
     return;
   }
   modalTitle.textContent = `Manage Subscriptions for ${recipientName}`;
+  if (pincodeEl) {
+    pincodeEl.textContent = recipientPincode ? `Pincode: ${recipientPincode}` : '';
+  }
   await _loadSubscriptionsForRecipientAndRenderIntoModal(recipientId, modalBody);
   modal.style.display = 'block';
   initialSubscriptionDataForModal = storeInitialFormStateHelper();
@@ -283,9 +287,10 @@ export function initSubscriptionsUI() {
     modal.innerHTML = `
       <div class="modal-dialog modal-lg">
         <div class="modal-content">
-          <div class="modal-header">
+          <div class="modal-header flex-column align-items-start">
             <h5 class="modal-title" id="subscriptionModalHeaderTitle">Manage Subscriptions</h5>
-            <button type="button" class="btn-close" id="subscriptionModalCloseButton" aria-label="Close"></button>
+            <p id="subscriptionModalPincode" class="mb-0 text-muted small"></p>
+            <button type="button" class="btn-close position-absolute top-0 end-0 mt-2 me-2" id="subscriptionModalCloseButton" aria-label="Close"></button>
           </div>
           <div class="modal-body" id="subscriptionModalBody"></div>
           <div class="modal-footer">

--- a/web/style.css
+++ b/web/style.css
@@ -953,6 +953,10 @@ button, .btn {
   color: #333; /* Ensure good contrast on the light header bg */
 }
 
+#subscriptionModalPincode {
+  margin-top: -0.25rem;
+}
+
 #subscriptionModal .modal-body {
   /* Existing: max-height: 450px; overflow-y: auto; */
   padding: 1rem 1.25rem; /* Standard Bootstrap modal body padding or adjust as needed */

--- a/web/test/recipients-ui.test.js
+++ b/web/test/recipients-ui.test.js
@@ -155,6 +155,7 @@ test('manage button opens modal when available', async () => {
   const li = makeEl();
   li.setAttribute('data-recipient-id', '2');
   li.setAttribute('data-recipient-email', 'c@d.com');
+  li.setAttribute('data-recipient-pincode', '111222');
   env.elements['recipients-list'].appendChild(li);
   const btn = {
     classList: { contains(c){ return c === 'manage-subscriptions-btn'; } },
@@ -162,8 +163,8 @@ test('manage button opens modal when available', async () => {
                    if(sel === 'li[data-recipient-id]') return li; return null; }
   };
   await trigger(env.elements['recipients-list'], 'click', { target: btn });
-  assert.deepStrictEqual(global.window.selectedRecipient, { id: '2', email: 'c@d.com' });
-  assert(args && args[0] === '2');
+  assert.deepStrictEqual(global.window.selectedRecipient, { id: '2', email: 'c@d.com', pincode: '111222' });
+  assert(args && args[0] === '2' && args[2] === '111222');
 });
 
 test('manage button alerts when modal missing', async () => {
@@ -176,6 +177,7 @@ test('manage button alerts when modal missing', async () => {
   const li = makeEl();
   li.setAttribute('data-recipient-id', '3');
   li.setAttribute('data-recipient-email', 'e@f.com');
+  li.setAttribute('data-recipient-pincode', '444555');
   env.elements['recipients-list'].appendChild(li);
   const btn = {
     classList: { contains(c){ return c === 'manage-subscriptions-btn'; } },
@@ -183,7 +185,7 @@ test('manage button alerts when modal missing', async () => {
                    if(sel === 'li[data-recipient-id]') return li; return null; }
   };
   await trigger(env.elements['recipients-list'], 'click', { target: btn });
-  assert.deepStrictEqual(global.window.selectedRecipient, { id: '3', email: 'e@f.com' });
+  assert.deepStrictEqual(global.window.selectedRecipient, { id: '3', email: 'e@f.com', pincode: '444555' });
   assert(alerted);
 });
 

--- a/web/test/subscription-modal.test.js
+++ b/web/test/subscription-modal.test.js
@@ -64,9 +64,10 @@ function makeEl(tag='div') {
 test('openSubscriptionModal fetches data and renders', async () => {
   const modal = makeEl('div');
   const title = makeEl('h5');
+  const pinEl = makeEl('p');
   const body = makeEl('div');
   const saveBtn = Object.assign(makeEl('button'), { disabled: true, innerHTML: '' });
-  const map = { subscriptionModal: modal, subscriptionModalHeaderTitle: title, subscriptionModalBody: body, saveAllSubscriptionsBtn: saveBtn };
+  const map = { subscriptionModal: modal, subscriptionModalHeaderTitle: title, subscriptionModalPincode: pinEl, subscriptionModalBody: body, saveAllSubscriptionsBtn: saveBtn };
   global.document = { getElementById: id => map[id] || null, createElement: tag => makeEl(tag), body: makeEl('body') };
   global.window = {};
   global.localStorage = { getItem: () => null };
@@ -76,8 +77,9 @@ test('openSubscriptionModal fetches data and renders', async () => {
     throw new Error('unexpected url ' + url);
   };
   const mod = await import('../components/subscription/subscription-modal.js?' + Date.now());
-  await mod.openSubscriptionModal(1, 'Bob');
+  await mod.openSubscriptionModal(1, 'Bob', '999999');
   assert.equal(title.textContent, 'Manage Subscriptions for Bob');
+  assert.equal(pinEl.textContent, 'Pincode: 999999');
   assert.equal(modal.style.display, 'block');
   assert.equal(body.children.length, 2);
   assert.equal(saveBtn.disabled, false);
@@ -153,12 +155,14 @@ test('saving subscription changes triggers API calls', async () => {
   map['subscriptionModal'] = modal;
   const header = makeEl('h5');
   header.id = 'subscriptionModalHeaderTitle';
+  const pinEl2 = makeEl('p');
   map['subscriptionModalHeaderTitle'] = header;
+  map['subscriptionModalPincode'] = pinEl2;
   const bodyEl = modalBody;
   body.appendChild(bodyEl);
   const saveBtn = map['saveAllSubscriptionsBtn'];
 
-  await mod.openSubscriptionModal(1, 'Bob');
+  await mod.openSubscriptionModal(1, 'Bob', '999999');
 
   const items = bodyEl.children;
   const first = items[0];


### PR DESCRIPTION
## Summary
- include recipient pincode when rendering admin recipient list
- pass pincode through manage subscription flow
- show pincode text in subscription modal header
- adjust tests for new pincode parameter
- small style tweak for modal pincode

## Testing
- `npm --prefix web test` *(fails: c8 not found)*
- `pytest -q` *(fails: missing async plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68661038bff0832fb998f695dcc1f920