### PR TITLE
Fix per-pincode summary aggregation

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PLAYWRIGHT_BROWSERS_PATH: pw-browsers
+    concurrency:
+      group: schedule-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -31,8 +34,8 @@ jobs:
 
       - name: Install deps
         run: |
-          pip install -r requirements.txt
-          playwright install chromium
+          pip install -r requirements.txt -q
+          playwright install chromium --with-deps
 
       - name: Run stock checker
         env:

--- a/scripts/notifications.py
+++ b/scripts/notifications.py
@@ -197,7 +197,8 @@ def format_summary_email_body(run_timestamp_str: str, summary_data_list: list, t
                 <tr>
                     <th>Product Name</th>
                     <th>In-Stock Streak</th>
-                    <th>Email (Pincode)</th>
+                    <th>Emails</th>
+                    <th>Pincode</th>
                 </tr>
             </thead>
             <tbody>
@@ -229,8 +230,7 @@ def format_summary_email_body(run_timestamp_str: str, summary_data_list: list, t
 
         for sub_info in subscriptions:
             user_email = sub_info.get('user_email', 'N/A')
-            pin = sub_info.get('pincode')
-            email_display = f"{user_email} ({pin})" if pin else user_email
+            email_display = user_email
             status = sub_info.get('status', 'N/A')
 
             if status == "Sent":
@@ -282,6 +282,7 @@ def format_summary_email_body(run_timestamp_str: str, summary_data_list: list, t
         <td><a href="{product_url}">{product_name}</a></td>
         <td>{streak}</td>
         <td>{subscribed_emails_csv}</td>
+        <td>{product_data.get("pincode", "N/A")}</td>
     </tr>
 """
 

--- a/tests/test_check_stock.py
+++ b/tests/test_check_stock.py
@@ -421,6 +421,7 @@ async def test_notify_users_email_host_not_set(monkeypatch):
         subscriptions,
         recipients_map,
         current_time,
+        "201305",
     )
     assert count == 0
     assert len(results) == 1
@@ -439,7 +440,7 @@ async def test_notify_users_email_sender_not_set(monkeypatch):
     current_time = dt_time(12, 0)
 
     results, count = await check_stock.notify_users(
-        "Test Product", "http://example.com/product", subscriptions, recipients_map, current_time
+        "Test Product", "http://example.com/product", subscriptions, recipients_map, current_time, "201305"
     )
     assert count == 0
     assert len(results) == 1
@@ -465,7 +466,7 @@ async def test_notify_users_send_email_exception(monkeypatch):
     current_time = dt_time(12, 0)
 
     results, count = await check_stock.notify_users(
-        "Test Product", "http://example.com/product", subscriptions, recipients_map, current_time
+        "Test Product", "http://example.com/product", subscriptions, recipients_map, current_time, "201305"
     )
     assert count == 0
     assert len(results) == 1
@@ -485,7 +486,7 @@ async def test_notify_users_empty_recipients_map(monkeypatch):
     current_time = dt_time(12, 0)
 
     results, count = await check_stock.notify_users(
-        "Test Product", "http://example.com/product", subscriptions, recipients_map, current_time
+        "Test Product", "http://example.com/product", subscriptions, recipients_map, current_time, "201305"
     )
     assert count == 0
     assert len(results) == 1
@@ -511,6 +512,7 @@ async def test_notify_users_recipient_not_found(monkeypatch):
         subscriptions,
         recipients_map,
         current_time,
+        "201305",
     )
     assert count == 0
     assert len(results) == 1
@@ -553,7 +555,7 @@ async def test_notify_users_mixed_subscriptions(monkeypatch):
     current_time = dt_time(12, 0) # For 12:00 PM
 
     results, count = await check_stock.notify_users(
-        "Test Product", "http://example.com/product", subscriptions, recipients_map, current_time
+        "Test Product", "http://example.com/product", subscriptions, recipients_map, current_time, "201305"
     )
 
     assert count == 3 # active1, active2, active_default
@@ -948,10 +950,9 @@ def test_aggregate_product_summaries():
         },
     ]
     result = check_stock.aggregate_product_summaries(summaries)
-    assert len(result) == 2
-    for item in result:
-        if item["product_id"] == 1:
-            assert len(item["subscriptions"]) == 2
+    assert len(result) == 3
+    combo_keys = {(r["product_id"], r["pincode"]) for r in result}
+    assert combo_keys == {(1, "111"), (1, "222"), (2, "333")}
 
 
 async def _run_notify_users(monkeypatch):
@@ -969,7 +970,7 @@ async def _run_notify_users(monkeypatch):
     subs = [{"recipient_id": 1, "start_time": "00:00", "end_time": "23:59"}]
     recipients = {1: {"email": "user@example.com", "pincode": "201305"}}
     result, count = await check_stock.notify_users(
-        "Prod", "url", subs, recipients, dt_time(12, 0)
+        "Prod", "url", subs, recipients, dt_time(12, 0), "201305"
     )
     return result, count, sent_args
 


### PR DESCRIPTION
## Summary
- aggregate summary by product & pincode
- keep pincode field in per-product summaries
- show pincode column in summary emails
- streamline schedule workflow and use concurrency

## Testing
- `pytest -q` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68665195f078832f8f0f828def3b58f7