### PR TITLE
Fix missing hash for pytest-asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -244,5 +244,5 @@ urllib3==2.5.0 \
     --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760
 yarl==1.20.1 \
     --hash=sha256:a97d67108e79cfe22e2b430d80d7571ae57d19f17cda8bb967057ca8a7bf5bfd
-pytest-asyncio==0.23.6
+pytest-asyncio==0.23.6 \
     --hash=sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a

--- a/requirements.txt
+++ b/requirements.txt
@@ -245,3 +245,4 @@ urllib3==2.5.0 \
 yarl==1.20.1 \
     --hash=sha256:a97d67108e79cfe22e2b430d80d7571ae57d19f17cda8bb967057ca8a7bf5bfd
 pytest-asyncio==0.23.6
+    --hash=sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a


### PR DESCRIPTION
## Summary
- pin hash for `pytest-asyncio` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686668044198832f94718788672e5657