### PR TITLE
Remove KV requirement for cleanup job

### DIFF
--- a/.github/workflows/monthly-cleanup.yml
+++ b/.github/workflows/monthly-cleanup.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Run cleanup script
         env:
-          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
-          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
           EMAIL_HOST: ${{ secrets.EMAIL_HOST }}
           EMAIL_PORT: ${{ secrets.EMAIL_PORT }}
           EMAIL_HOST_USER: ${{ secrets.EMAIL_HOST_USER }}


### PR DESCRIPTION
## Summary
- remove Vercel KV usage from `cleanup-non-subs.js`
- fetch recipients and subscriptions via API
- adjust monthly cleanup workflow to drop KV env vars

## Testing
- `pytest -q`
- `npm --prefix web test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867665623dc832f8039f55ce01c4788