### PR TITLE
Enable text to toggle collapses on mobile

### DIFF
--- a/web/components/user-subscriptions/user-subscriptions.html
+++ b/web/components/user-subscriptions/user-subscriptions.html
@@ -4,7 +4,7 @@
       <a href="#" class="d-sm-none collapse-toggle me-2" data-bs-toggle="collapse" data-bs-target="#userSubscribedListCollapse" aria-expanded="true" aria-controls="userSubscribedListCollapse">
         <i data-lucide="chevron-down"></i>
       </a>
-      <span>Your Subscriptions</span>
+      <span class="collapse-title" role="button" data-bs-toggle="collapse" data-bs-target="#userSubscribedListCollapse" aria-expanded="true" aria-controls="userSubscribedListCollapse">Your Subscriptions</span>
     </h4>
     <div class="modal fade" id="subscriptionsInfoModal" tabindex="-1" aria-labelledby="subscriptionsInfoModalLabel" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
@@ -38,7 +38,7 @@
       <a href="#" class="d-sm-none collapse-toggle me-2" data-bs-toggle="collapse" data-bs-target="#allProductsListCollapse" aria-expanded="true" aria-controls="allProductsListCollapse">
         <i data-lucide="chevron-down"></i>
       </a>
-      <h4 class="mb-0">Available Products</h4>
+        <h4 class="mb-0 collapse-title" role="button" data-bs-toggle="collapse" data-bs-target="#allProductsListCollapse" aria-expanded="true" aria-controls="allProductsListCollapse">Available Products</h4>
     </div>
     <input type="text" id="product-search" class="form-control mb-2" placeholder="Search products">
     <div class="collapse show" id="allProductsListCollapse">

--- a/web/style.css
+++ b/web/style.css
@@ -373,6 +373,10 @@ button, .btn {
   transform: rotate(-90deg);
 }
 
+#subscriptions-ui .collapse-title {
+  cursor: pointer;
+}
+
 @media (max-width: 767.98px) {
   #subscriptions-ui .list-wrapper {
     max-height: none;


### PR DESCRIPTION
## Summary
- allow clicking on section titles to expand/collapse subscription lists
- style titles to indicate they are clickable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678eda4ef4832f870f42aaed52a290