### PR TITLE
Add gradient user background and fix admin FAB icon

### DIFF
--- a/web/components/admin-main/admin.html
+++ b/web/components/admin-main/admin.html
@@ -141,7 +141,7 @@
   </div> <!-- End of container -->
   </div> <!-- End of main-app-content -->
   <button type="button" class="fab interactive-hover" data-bs-toggle="offcanvas" data-bs-target="#settingsPane" aria-controls="settingsPane" aria-label="Open Settings">
-    <i data-lucide="settings"></i>
+    <i data-lucide="sliders"></i>
   </button>
 
   <div class="offcanvas offcanvas-end" tabindex="-1" id="settingsPane" aria-labelledby="settingsPaneLabel">

--- a/web/components/user-main/user.css
+++ b/web/components/user-main/user.css
@@ -15,10 +15,18 @@
 
     body {
   font-family: "Inter", sans-serif;
-  background: #111;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
+  background-size: 400% 400%;
+  animation: gradientShift 15s ease infinite;
   min-height: 100vh;
   overflow-x: hidden;
 }
+
+    @keyframes gradientShift {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
     #particles-js {
       position: fixed;
       width: 100%;


### PR DESCRIPTION
## Summary
- sync the admin FAB icon with user mode
- add animated gradient background in user mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686811283a44832f86690a132f999835