### PR TITLE
Fix loader spinner on invalid admin login

### DIFF
--- a/web/components/login/login.js
+++ b/web/components/login/login.js
@@ -223,6 +223,7 @@ export async function initLogin() {
     const password = adminPasswordInput ? adminPasswordInput.value.trim() : '';
     if (!email || !password) {
       showError(adminErrorMessage, 'Please enter both email and password.');
+      hideGlobalLoader();
       return;
     }
     try {
@@ -259,6 +260,7 @@ export async function initLogin() {
     if (email === '') {
       showError(userErrorMessage, 'Please enter your email.');
       if (userContactLinks) userContactLinks.style.display = 'none';
+      hideGlobalLoader();
       return;
     }
     try {


### PR DESCRIPTION
## Summary
- ensure loader hides when admin or user login fails due to missing credentials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686817960038832f9e256fb581a8a71d