### PR TITLE
Fix login icon when popup injected

### DIFF
--- a/web/components/login/login.js
+++ b/web/components/login/login.js
@@ -23,7 +23,10 @@ export async function initLogin() {
   const adminRoleBtn = document.getElementById('admin-role-btn');
   const userRoleBtn = document.getElementById('user-role-btn');
 
-  const loginIcon = loginPopup ? loginPopup.querySelector('.login-icon i') : null;
+  const loginIcon =
+    loginPopup && typeof loginPopup.querySelector === 'function'
+      ? loginPopup.querySelector('.login-icon i')
+      : null;
 
   const adminSection = document.getElementById('admin-section');
   const userSection = document.getElementById('user-section');


### PR DESCRIPTION
## Summary
- guard against missing querySelector on login popup

## Testing
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868213efde4832f802412072023ad09