### PR TITLE
Add custom pincode recipient filter

### DIFF
--- a/web/api/email-blast.js
+++ b/web/api/email-blast.js
@@ -82,6 +82,10 @@ export default async function handler(req, res) {
           allRecipients.forEach(r => {
             if (r.pincode === '201305') addUnique(r.email);
           });
+        } else if (recipientType === 'custom-pincode') {
+          allRecipients.forEach(r => {
+            if (r.pincode && r.pincode !== '201305') addUnique(r.email);
+          });
         } else if (recipientType === 'no-pincode') {
           allRecipients.forEach(r => {
             if (!r.pincode) addUnique(r.email);

--- a/web/components/admin-main/admin-main.js
+++ b/web/components/admin-main/admin-main.js
@@ -125,6 +125,8 @@ document.addEventListener('DOMContentLoaded', () => {
             baseRecipients = recips.filter(r => pausedSubs.has(r.id)).map(r => r.email);
           } else if (type === 'default-pincode') {
             baseRecipients = recips.filter(r => r.pincode === '201305').map(r => r.email);
+          } else if (type === 'custom-pincode') {
+            baseRecipients = recips.filter(r => r.pincode && r.pincode !== '201305').map(r => r.email);
           } else if (type === 'no-pincode') {
             baseRecipients = recips.filter(r => !r.pincode).map(r => r.email);
           } else {

--- a/web/components/admin-main/admin.html
+++ b/web/components/admin-main/admin.html
@@ -231,6 +231,10 @@
                 <label class="form-check-label text-white" for="recipient-default-pincode">With default pincode</label>
               </div>
               <div class="form-check me-3 mb-2">
+                <input class="form-check-input" type="radio" name="recipientType" id="recipient-custom-pincode" value="custom-pincode">
+                <label class="form-check-label text-white" for="recipient-custom-pincode">With custom pincode</label>
+              </div>
+              <div class="form-check me-3 mb-2">
                 <input class="form-check-input" type="radio" name="recipientType" id="recipient-no-pincode" value="no-pincode">
                 <label class="form-check-label text-white" for="recipient-no-pincode">Without pincode</label>
               </div>


### PR DESCRIPTION
## Summary
- update admin email blast modal to allow targeting users who changed their pincode
- support custom-pincode recipient type in admin JS logic
- handle custom-pincode on the email-blast API

## Testing
- `pytest -q`
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686825e922fc832f80c01a4647a6a6b2