### PR TITLE
Improve concurrent product checks

### DIFF
--- a/scripts/check_stock.py
+++ b/scripts/check_stock.py
@@ -453,37 +453,74 @@ async def main():
             browser = await pw.chromium.launch(headless=True, args=["--no-sandbox"])
 
             async def process_pincode(pincode, recips_subset):
-                page = await browser.new_page()
-                entered = False
+                """Handle all products for a given pincode concurrently."""
                 results = []
+
+                subs_subset = {
+                    pid: [s for s in subs if s.get("recipient_id") in recips_subset]
+                    for pid, subs in subs_map.items()
+                }
+
+                # Filter products that actually need checking
+                products_to_check = []
+                for product_info in all_products:
+                    pid = product_info.get("id")
+                    product_subs = subs_subset.get(pid, [])
+                    if filter_active_subs(product_subs, current_time):
+                        products_to_check.append(product_info)
+
+                if not products_to_check:
+                    return results
+
+                # Open a page once to set the pincode and obtain cookies for the context
+                setup_page = await browser.new_page()
                 try:
-                    subs_subset = {
-                        pid: [s for s in subs if s.get("recipient_id") in recips_subset]
-                        for pid, subs in subs_map.items()
-                    }
-                    for product_info in all_products:
-                        pid = product_info.get("id")
-                        product_subs = subs_subset.get(pid, [])
-                        if not filter_active_subs(product_subs, current_time):
-                            continue
-                        summary, sent, entered = await process_product(
-                            session,
-                            page,
-                            product_info,
-                            recips_subset,
-                            current_time,
-                            entered,
-                            subs_subset,
-                            pincode,
-                        )
-                        results.append((product_info, summary, sent))
+                    # Use the first product page to set the pincode
+                    first = products_to_check[0]
+                    summary, sent, _ = await process_product(
+                        session,
+                        setup_page,
+                        first,
+                        recips_subset,
+                        current_time,
+                        False,  # enter pincode
+                        subs_subset,
+                        pincode,
+                    )
+                    results.append((first, summary, sent))
                 finally:
-                    if hasattr(page, "close"):
-                        close_fn = page.close
+                    if hasattr(setup_page, "close"):
+                        close_fn = setup_page.close
                         if inspect.iscoroutinefunction(close_fn):
                             await close_fn()
                         else:
                             close_fn()
+
+                async def handle_product(prod_info):
+                    page = await browser.new_page()
+                    try:
+                        summary, sent, _ = await process_product(
+                            session,
+                            page,
+                            prod_info,
+                            recips_subset,
+                            current_time,
+                            True,  # pincode already entered
+                            subs_subset,
+                            pincode,
+                        )
+                        return (prod_info, summary, sent)
+                    finally:
+                        if hasattr(page, "close"):
+                            close_fn = page.close
+                            if inspect.iscoroutinefunction(close_fn):
+                                await close_fn()
+                            else:
+                                close_fn()
+
+                tasks = [handle_product(p) for p in products_to_check[1:]]
+                if tasks:
+                    results.extend(await asyncio.gather(*tasks))
                 return results
 
             pincode_tasks = [


### PR DESCRIPTION
## Summary
- process each pincode by setting it once and running product checks concurrently
- open and close a new page per product

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e4cb4390832f93e15a3768da9ec3