### PR TITLE
Merge fix and refine concurrent product checks

### DIFF
--- a/tests/test_check_stock.py
+++ b/tests/test_check_stock.py
@@ -1043,7 +1043,6 @@ def test_process_product_missing_data():
 
 
 def test_process_product_out_of_stock(monkeypatch):
-    monkeypatch.setattr(check_stock, "filter_active_subs", lambda subs, ct: subs)
 
     async def fake_check(url, pin, page=None, skip_pincode=False, log_prefix=""):
         return False, "Scraped"
@@ -1070,7 +1069,6 @@ def test_process_product_out_of_stock(monkeypatch):
 
 
 def test_process_product_in_stock(monkeypatch):
-    monkeypatch.setattr(check_stock, "filter_active_subs", lambda subs, ct: subs)
 
     async def fake_notify(*a, **k):
         return ([{"user_email": "u@example.com", "status": "Sent"}], 1)


### PR DESCRIPTION
## Summary
- merge latest main updates into working branch
- filter active subscriptions per pincode before running concurrent checks
- create a setup page for pincode entry then spawn product tasks with their own pages
- drop obsolete test monkeypatches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e4cb4390832f93e15a3768da9ec3