### PR TITLE
Optimize subscription lookups

### DIFF
--- a/tests/test_check_stock.py
+++ b/tests/test_check_stock.py
@@ -934,6 +934,22 @@ def test_filter_active_subs():
     assert len(active) == 1
 
 
+def test_build_subs_by_pincode():
+    recipients = {
+        1: {"email": "a@example.com", "pincode": "111"},
+        2: {"email": "b@example.com", "pincode": "222"},
+    }
+    sub_a = {"recipient_id": 1, "product_id": 10}
+    sub_b = {"recipient_id": 2, "product_id": 10}
+    sub_c = {"recipient_id": 1, "product_id": 20}
+    subs_map = {10: [sub_a, sub_b], 20: [sub_c, {"recipient_id": 3}]}
+    result = check_stock.build_subs_by_pincode(recipients, subs_map)
+    assert result == {
+        "111": {10: [sub_a], 20: [sub_c]},
+        "222": {10: [sub_b]},
+    }
+
+
 def test_aggregate_product_summaries():
     summaries = [
         {


### PR DESCRIPTION
## Summary
- build helper `build_subs_by_pincode` for quick lookup of subscriptions by pincode
- use new mapping inside `main` to avoid recomputing active subs
- test `build_subs_by_pincode`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f1c52504832fb37d31f3ced0ab94