### PR TITLE
Improve scraper waits

### DIFF
--- a/scripts/scraper.py
+++ b/scripts/scraper.py
@@ -22,7 +22,7 @@ async def _check_availability_on_page(
     await log("Navigating to", url)
     await page.goto(url, timeout=60000)
     await page.wait_for_load_state("networkidle")
-    await asyncio.sleep(1)
+    await page.wait_for_timeout(500)
     await log("Page loaded")
 
     async def handle_pincode_modal():
@@ -39,7 +39,6 @@ async def _check_availability_on_page(
             return
         await log("Pincode input found → typing", pincode)
         await pincode_input.fill(pincode)
-        await asyncio.sleep(3)
         await log("Pincode typed")
         try:
             await page.wait_for_selector("#automatic", timeout=5000)
@@ -54,7 +53,7 @@ async def _check_availability_on_page(
             await log(f"Could not click suggestion for {pincode}, trying keyboard.")
             await page.keyboard.press("ArrowDown")
             await page.keyboard.press("Enter")
-        await asyncio.sleep(3)
+        await page.wait_for_timeout(500)
         await page.wait_for_load_state("networkidle")
         await log("Pincode selected/attempted")
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -94,6 +94,9 @@ class MockPage:
         self.waited_for_load_state = state
         # print(f"MockPage: Waited for load state '{state}'")
 
+    async def wait_for_timeout(self, timeout):
+        await asyncio.sleep(timeout / 1000)
+
     async def query_selector(self, selector):
         # print(f"MockPage: Querying selector '{selector}'")
         config = self.selectors_config.get(selector)


### PR DESCRIPTION
## Summary
- replace long `asyncio.sleep` calls in `scraper.py` with Playwright waits
- support `page.wait_for_timeout` in test `MockPage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be77b4ad0832faa36e2b104cf2f1a