### PR TITLE
Enable parallel product checking

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -21,4 +21,6 @@ RUN_OFFSET_MINUTES = 15
 
 # Base URL for the application itself, used for constructing absolute URLs if needed
 APP_BASE_URL = os.getenv("APP_BASE_URL", "http://localhost:3000")
+# Maximum number of product pages to check in parallel
+MAX_PARALLEL_PAGE_CHECKS = int(os.getenv("MAX_PARALLEL_PAGE_CHECKS", "5"))
 # ——————————————————————————————————————————


### PR DESCRIPTION
## Summary
- add configurable `MAX_PARALLEL_PAGE_CHECKS` setting
- process products concurrently in `check_stock`
- test concurrent processing by measuring runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf1a53074832f90d41dc2080ceaa7