### PR TITLE
Reduce auto-pause threshold

### DIFF
--- a/scripts/check_stock.py
+++ b/scripts/check_stock.py
@@ -225,7 +225,7 @@ async def main():
                             stock_counters[key] = 0
                         streak = stock_counters.get(key, 0)
                         summary["consecutive_in_stock"] = streak
-                        if streak > 30:
+                        if streak > 20:
                             for sub in subs_map.get(pid, []):
                                 rid = sub.get("recipient_id")
                                 rec_pin = recipients_map.get(rid, {}).get(

--- a/tests/test_check_stock.py
+++ b/tests/test_check_stock.py
@@ -1291,7 +1291,7 @@ async def test_auto_pause_after_streak(monkeypatch):
         return subs_map
 
     async def mock_load_stock_counters(session):
-        return {"1|111": 30}
+        return {"1|111": 20}
 
     saved = {}
 
@@ -1376,7 +1376,7 @@ async def test_auto_pause_after_streak(monkeypatch):
     assert called.get("called")
     assert called.get("paused") is True
     assert subs_map[1][0]["paused"] is True
-    assert saved.get("1|111") == 31
+    assert saved.get("1|111") == 21
     assert email_called.get("called")
     assert email_called.get("recipients") == ["u@example.com"]
     assert "Prod" in email_called.get("body", "")


### PR DESCRIPTION
## Summary
- reduce the auto-pause threshold in `check_stock.py` from 30 to 20
- update corresponding test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b05147be0832fb93bfc447166620d