### PR TITLE
Display recipient count in admin panel

### DIFF
--- a/web/components/admin-main/admin.html
+++ b/web/components/admin-main/admin.html
@@ -124,7 +124,7 @@
                       <div id="add-product-error-message" class="mt-3"></div>
                     </form>
                     <div id="products-list-container">
-                      <h5 class="mt-4 mb-3">📋 Current Products:</h5>
+                      <h5 class="mt-4 mb-3">📋 Current Products: <span id="products-count" class="badge bg-secondary">0</span></h5>
                       <ul id="products-list" class="list-group">
                         <!-- Products will be listed here -->
                         <li class="list-group-item d-flex justify-content-between align-items-center">

--- a/web/components/admin-main/admin.html
+++ b/web/components/admin-main/admin.html
@@ -74,7 +74,7 @@
                       <div id="add-recipient-error-message" class="mt-3"></div>
                     </form>
                     <div id="recipients-list-container">
-                      <h5 class="mt-4 mb-3">📋 Current Recipients:</h5>
+                      <h5 class="mt-4 mb-3">📋 Current Recipients: <span id="recipients-count" class="badge bg-secondary">0</span></h5>
                       <ul id="recipients-list" class="list-group">
                         <!-- Recipients will be listed here -->
                         <li class="list-group-item d-flex justify-content-between align-items-center">

--- a/web/components/products-ui/products-ui.js
+++ b/web/components/products-ui/products-ui.js
@@ -49,7 +49,13 @@ function clearError(elementId) {
 // Renders the list of products
 function renderProductsList(products) {
   const productsListEl = document.getElementById('products-list');
+  const productsCount = document.getElementById('products-count');
   productsListEl.innerHTML = ''; // Clear current list
+
+  const count = products && Array.isArray(products) ? products.length : 0;
+  if (productsCount) {
+    productsCount.textContent = count;
+  }
 
   if (!products || products.length === 0) {
     productsListEl.innerHTML = '<li class="list-group-item">No products found.</li>';
@@ -122,6 +128,10 @@ async function fetchProducts() {
     console.error('Error fetching products:', error);
     const productsListEl = document.getElementById('products-list');
     productsListEl.innerHTML = `<li class="list-group-item list-group-item-danger">Error loading products: ${error.message}</li>`;
+    const productsCount = document.getElementById('products-count');
+    if (productsCount) {
+      productsCount.textContent = '0';
+    }
   }
 }
 

--- a/web/components/recipients-ui/recipients-ui.js
+++ b/web/components/recipients-ui/recipients-ui.js
@@ -68,7 +68,13 @@ async function fetchAPI(url, options = {}) {
 function renderRecipientsList(recipients) {
   const recipientsList = document.getElementById('recipients-list');
   const recipientSubscriptionsSection = document.getElementById('recipient-subscriptions-section');
+  const recipientCount = document.getElementById('recipients-count');
   recipientsList.innerHTML = ''; // Clear current list
+
+  const count = recipients && Array.isArray(recipients) ? recipients.length : 0;
+  if (recipientCount) {
+    recipientCount.textContent = count;
+  }
 
   if (!recipients || recipients.length === 0) {
     recipientsList.innerHTML = '<li class="list-group-item">No recipients found.</li>';
@@ -136,6 +142,10 @@ async function fetchRecipients() {
     console.error('Error fetching recipients:', error);
     const recipientsList = document.getElementById('recipients-list');
     recipientsList.innerHTML = `<li class="list-group-item list-group-item-danger">Error loading recipients: ${error.message}</li>`;
+    const recipientCount = document.getElementById('recipients-count');
+    if (recipientCount) {
+      recipientCount.textContent = '0';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- show total recipient count next to "Current Recipients" in the admin dashboard
- update recipient UI logic to keep the count in sync when list changes or errors

## Testing
- `pytest -q`
- `node --test tests/js/*.mjs`


------
https://chatgpt.com/codex/tasks/task_e_688f66b056bc832f9605ab81ad70e1db