### PR TITLE
Handle missing DOM APIs in user subscriptions UI

### DIFF
--- a/web/components/user-subscriptions/user-subscriptions.js
+++ b/web/components/user-subscriptions/user-subscriptions.js
@@ -41,13 +41,20 @@ export async function initUserSubscriptionsUI() {
   const collapsibleSections = [productsCollapse, subscribedCollapse].filter(Boolean);
   const collapseToggleMap = new Map();
 
-  document.querySelectorAll('.panel-toggle[data-collapsible-target]').forEach(btn => {
+  const toggleButtons = typeof document?.querySelectorAll === 'function'
+    ? Array.from(document.querySelectorAll('.panel-toggle[data-collapsible-target]'))
+    : [];
+
+  toggleButtons.forEach(btn => {
     collapseToggleMap.set(btn.dataset.collapsibleTarget, btn);
   });
 
   function updateCollapseMode() {
     if (typeof bootstrap === 'undefined' || !bootstrap.Collapse) return;
-    const isMobile = window.innerWidth < 1200;
+    const viewportWidth = typeof window !== 'undefined' && typeof window.innerWidth === 'number'
+      ? window.innerWidth
+      : 1200;
+    const isMobile = viewportWidth < 1200;
 
     collapsibleSections.forEach(section => {
       const selector = `#${section.id}`;
@@ -79,7 +86,9 @@ export async function initUserSubscriptionsUI() {
     section.addEventListener('hide.bs.collapse', () => toggle.setAttribute('aria-expanded', 'false'));
   });
 
-  window.addEventListener('resize', updateCollapseMode);
+  if (typeof window?.addEventListener === 'function') {
+    window.addEventListener('resize', updateCollapseMode);
+  }
   updateCollapseMode();
 
   function createSubscribedItem(product, sub, paused = false) {


### PR DESCRIPTION
## Summary
- guard the user subscriptions UI against missing document query selectors
- provide a fallback viewport width and optional resize listener when running without the browser APIs

## Testing
- node --test test/user-subscriptions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d028812e4c832fa3b3203bf7671a03