### PR TITLE
Handle KV read failures and add daily backup

### DIFF
--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -1,0 +1,38 @@
+name: Daily KV backup
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.3.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -q
+
+      - name: Export KV snapshot
+        env:
+          APP_BASE_URL: ${{ secrets.APP_BASE_URL }}
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: python scripts/export_kv_snapshot.py
+
+      - name: Upload KV snapshot
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: kv-snapshot
+          path: backups
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/export_kv_snapshot.py
+++ b/scripts/export_kv_snapshot.py
@@ -1,0 +1,119 @@
+"""Export the current KV-backed datasets to a JSON snapshot.
+
+The script is designed to run in GitHub Actions on a schedule so we always
+have a recent copy of the data should the KV store ever hiccup. It fetches the
+public API endpoints (products, recipients, subscriptions, and stock counters)
+and stores them in a timestamped JSON file that can be downloaded as an
+artifact.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+import json
+import os
+import sys
+from pathlib import Path
+import types
+
+try:
+    import aiohttp  # type: ignore
+except Exception:  # pragma: no cover - fallback when aiohttp not installed
+    aiohttp = types.SimpleNamespace()
+
+# Allow running via `python scripts/export_kv_snapshot.py`
+if __package__ is None and __name__ == "__main__":
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import config  # noqa: E402
+
+# Provide a minimal fallback ClientSession when aiohttp is not fully available
+if not hasattr(aiohttp, "ClientSession"):
+    class _DummyResponse:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def json(self):
+            return {}
+
+        def raise_for_status(self):
+            pass
+
+    class _DummyClientSession:
+        def __init__(self):
+            self.headers = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def _response(self):
+            return _DummyResponse()
+
+        def get(self, _url, **_kwargs):
+            return self._response()
+
+    aiohttp.ClientSession = _DummyClientSession  # type: ignore[attr-defined]
+
+
+API_PATHS = {
+    "products": "/api/products",
+    "recipients": "/api/recipients",
+    "subscriptions": "/api/subscriptions",
+    "stock_counters": "/api/stock-counters",
+}
+
+
+async def fetch_endpoint(session, path, headers):
+    base = config.APP_BASE_URL.rstrip("/")
+    url = f"{base}{path}"
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        return await response.json()
+
+
+async def export_snapshot():
+    headers = None
+    token = getattr(config, "ADMIN_TOKEN", None)
+    if token:
+        headers = {"Authorization": f"Bearer {token}"}
+
+    results = {}
+    async with aiohttp.ClientSession() as session:
+        for key, path in API_PATHS.items():
+            data = await fetch_endpoint(session, path, headers)
+            results[key] = data
+
+    generated_at = datetime.now(timezone.utc).isoformat()
+    snapshot = {
+        "generated_at": generated_at,
+        "app_base_url": config.APP_BASE_URL,
+        "data": results,
+    }
+
+    snapshot_dir = Path(os.getenv("SNAPSHOT_DIR", "backups"))
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = os.getenv("SNAPSHOT_FILE")
+    if filename:
+        path = Path(filename)
+        if not path.is_absolute():
+            path = snapshot_dir / path
+    else:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        path = snapshot_dir / f"kv-backup-{timestamp}.json"
+
+    path.write_text(json.dumps(snapshot, indent=2, sort_keys=True))
+    print(f"Snapshot written to {path} with keys: {', '.join(sorted(results.keys()))}")
+
+
+def main():
+    asyncio.run(export_snapshot())
+
+
+if __name__ == "__main__":
+    main()

--- a/web/api/products.js
+++ b/web/api/products.js
@@ -1,23 +1,42 @@
 import { kv } from '@vercel/kv';
-import { requireAdmin } from '../utils/auth.js';
+import { requireAdmin as defaultRequireAdmin } from '../utils/auth.js';
+
+let kvClient = kv;
+let requireAdmin = defaultRequireAdmin;
+
+export function __setKv(mock) {
+  kvClient = mock;
+}
+
+export function __resetKv() {
+  kvClient = kv;
+}
+
+export function __setRequireAdmin(fn) {
+  requireAdmin = fn;
+}
+
+export function __resetRequireAdmin() {
+  requireAdmin = defaultRequireAdmin;
+}
 
 // KV Helper functions for Products
 async function getProductsFromKV() {
   try {
-    const productsData = await kv.get('products');
+    const productsData = await kvClient.get('products');
     if (productsData) {
       productsData.sort((a, b) => a.name.localeCompare(b.name));
     }
     return productsData ? productsData : [];
   } catch (error) {
     console.error('Error fetching products from KV:', error);
-    return [];
+    throw error;
   }
 }
 
 async function saveProductsToKV(productsArray) {
   try {
-    await kv.set('products', productsArray);
+    await kvClient.set('products', productsArray);
   } catch (error) {
     console.error('Error saving products to KV:', error);
     throw new Error('Could not save products to KV.');
@@ -27,17 +46,17 @@ async function saveProductsToKV(productsArray) {
 // KV Helper functions for Subscriptions (needed for cascading delete)
 async function getSubscriptionsFromKV() {
   try {
-    const subscriptionsData = await kv.get('subscriptions');
+    const subscriptionsData = await kvClient.get('subscriptions');
     return subscriptionsData ? subscriptionsData : [];
   } catch (error) {
     console.error('Error fetching subscriptions from KV:', error);
-    return [];
+    throw error;
   }
 }
 
 async function saveSubscriptionsToKV(subscriptionsArray) {
   try {
-    await kv.set('subscriptions', subscriptionsArray);
+    await kvClient.set('subscriptions', subscriptionsArray);
   } catch (error) {
     console.error('Error saving subscriptions to KV:', error);
     throw new Error('Could not save subscriptions to KV.');

--- a/web/api/recipients.js
+++ b/web/api/recipients.js
@@ -1,22 +1,39 @@
 import { kv } from '@vercel/kv';
-import { requireAdmin } from '../utils/auth.js';
+import { requireAdmin as defaultRequireAdmin } from '../utils/auth.js';
+
+let kvClient = kv;
+let requireAdmin = defaultRequireAdmin;
+
+export function __setKv(mock) {
+  kvClient = mock;
+}
+
+export function __resetKv() {
+  kvClient = kv;
+}
+
+export function __setRequireAdmin(fn) {
+  requireAdmin = fn;
+}
+
+export function __resetRequireAdmin() {
+  requireAdmin = defaultRequireAdmin;
+}
 
 // KV Helper functions for Recipients
 async function getRecipientsFromKV() {
   try {
-    const recipientsData = await kv.get('recipients');
+    const recipientsData = await kvClient.get('recipients');
     return recipientsData ? recipientsData : []; // KV returns the object directly if stored as such
   } catch (error) {
     console.error('Error fetching recipients from KV:', error);
-    // Fallback to empty array or throw, depending on desired error handling
-    // For this API, returning empty array and letting handler decide on 500 is fine
-    return [];
+    throw error;
   }
 }
 
 async function saveRecipientsToKV(recipientsArray) {
   try {
-    await kv.set('recipients', recipientsArray);
+    await kvClient.set('recipients', recipientsArray);
   } catch (error) {
     console.error('Error saving recipients to KV:', error);
     throw new Error('Could not save recipients to KV.');
@@ -26,17 +43,17 @@ async function saveRecipientsToKV(recipientsArray) {
 // KV Helper functions for Subscriptions (needed for cascading delete)
 async function getSubscriptionsFromKV() {
   try {
-    const subscriptionsData = await kv.get('subscriptions');
+    const subscriptionsData = await kvClient.get('subscriptions');
     return subscriptionsData ? subscriptionsData : [];
   } catch (error) {
     console.error('Error fetching subscriptions from KV:', error);
-    return [];
+    throw error;
   }
 }
 
 async function saveSubscriptionsToKV(subscriptionsArray) {
   try {
-    await kv.set('subscriptions', subscriptionsArray);
+    await kvClient.set('subscriptions', subscriptionsArray);
   } catch (error) {
     console.error('Error saving subscriptions to KV:', error);
     throw new Error('Could not save subscriptions to KV.');

--- a/web/api/subscriptions.js
+++ b/web/api/subscriptions.js
@@ -1,18 +1,28 @@
 import { kv } from '@vercel/kv';
 
+let kvClient = kv;
+
+export function __setKv(mock) {
+  kvClient = mock;
+}
+
+export function __resetKv() {
+  kvClient = kv;
+}
+
 async function getFromKV(key) {
   try {
-    const data = await kv.get(key);
+    const data = await kvClient.get(key);
     return data ? data : [];
   } catch (error) {
     console.error(`Error fetching ${key} from KV:`, error);
-    return [];
+    throw error;
   }
 }
 
 async function saveToKV(key, data) {
   try {
-    await kv.set(key, data);
+    await kvClient.set(key, data);
   } catch (error) {
     console.error(`Error saving ${key} to KV:`, error);
     throw new Error(`Could not save ${key} to KV.`);

--- a/web/test/api-kv-failures.test.js
+++ b/web/test/api-kv-failures.test.js
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'assert';
+
+function makeRes() {
+  return {
+    code: null,
+    data: null,
+    headers: {},
+    status(c) { this.code = c; return this; },
+    json(d) { this.data = d; return this; },
+    setHeader(k, v) { this.headers[k] = v; return this; }
+  };
+}
+
+test('POST /api/products returns 500 when kv.get fails and avoids kv.set', async () => {
+  const modulePath = '../api/products.js?' + Date.now();
+  const mod = await import(modulePath);
+  let setCalled = false;
+  mod.__setKv({
+    async get() { throw new Error('kv down'); },
+    async set() { setCalled = true; }
+  });
+  mod.__setRequireAdmin(() => true);
+
+  const req = {
+    method: 'POST',
+    body: { url: 'https://example.com', name: 'Example' },
+    headers: {}
+  };
+  const res = makeRes();
+  await mod.default(req, res);
+  assert.equal(res.code, 500);
+  assert.equal(res.data?.message, 'Error saving product to KV');
+  assert.equal(setCalled, false);
+  mod.__resetKv();
+  mod.__resetRequireAdmin();
+});
+
+test('POST /api/recipients surfaces kv errors without writing empty data', async () => {
+  const modulePath = '../api/recipients.js?' + Date.now();
+  const mod = await import(modulePath);
+  let setCalled = false;
+  mod.__setKv({
+    async get() { throw new Error('kv down'); },
+    async set() { setCalled = true; }
+  });
+  mod.__setRequireAdmin(() => true);
+
+  const req = {
+    method: 'POST',
+    body: { email: 'user@example.com', pincode: '201305' },
+    headers: {}
+  };
+  const res = makeRes();
+  await mod.default(req, res);
+  assert.equal(res.code, 500);
+  assert.equal(res.data?.message, 'Error saving recipient to KV');
+  assert.equal(setCalled, false);
+  mod.__resetKv();
+  mod.__resetRequireAdmin();
+});
+
+test('POST /api/subscriptions reports kv failure without persisting data', async () => {
+  const modulePath = '../api/subscriptions.js?' + Date.now();
+  const mod = await import(modulePath);
+  let setCalled = false;
+  mod.__setKv({
+    async get(key) {
+      if (key === 'recipients') {
+        return [{ id: 'r1', email: 'user@example.com' }];
+      }
+      if (key === 'products') {
+        return [{ id: 'p1', name: 'Example' }];
+      }
+      if (key === 'subscriptions') {
+        throw new Error('kv down');
+      }
+      throw new Error('unexpected key ' + key);
+    },
+    async set() { setCalled = true; }
+  });
+
+  const req = {
+    method: 'POST',
+    body: { recipient_id: 'r1', product_id: 'p1', start_time: '08:00', end_time: '20:00', paused: false }
+  };
+  const res = makeRes();
+  await mod.default(req, res);
+  assert.equal(res.code, 500);
+  assert.equal(res.data?.message, 'Error creating subscription in KV');
+  assert.equal(setCalled, false);
+  mod.__resetKv();
+});


### PR DESCRIPTION
## Summary
- propagate KV read errors in the products, recipients, and subscriptions APIs so KV outages no longer overwrite data and expose helpers to aid testing
- add regression tests that simulate KV read failures and verify the APIs return 500 responses without persisting empty payloads
- introduce a daily GitHub Actions workflow plus a snapshot script that exports all KV-backed data to a downloadable JSON artifact

## Testing
- node --test web/test
- pytest
- npm --prefix web test *(fails: missing local c8 binary because npm install cannot reach @vercel/kv registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2754c6b68832fbcd4f62a939c6f7d