### PR TITLE
Optimize API configuration fetches and GitHub caching

### DIFF
--- a/web/api/_kv-helpers.js
+++ b/web/api/_kv-helpers.js
@@ -1,0 +1,384 @@
+import { kv } from '@vercel/kv';
+
+const RECIPIENTS_HASH_KEY = 'recipients:data';
+const LEGACY_RECIPIENTS_KEY = 'recipients';
+
+const PRODUCTS_HASH_KEY = 'products:data';
+const LEGACY_PRODUCTS_KEY = 'products';
+
+const SUBSCRIPTIONS_HASH_KEY = 'subscriptions:data';
+const LEGACY_SUBSCRIPTIONS_KEY = 'subscriptions';
+
+const STOCK_COUNTERS_HASH_KEY = 'stock_counters:data';
+const LEGACY_STOCK_COUNTERS_KEY = 'stock_counters';
+
+function parseJSON(value, fallback = {}) {
+  if (value == null) return { ...fallback };
+  if (typeof value === 'object') return { ...fallback, ...value };
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object') {
+      return { ...fallback, ...parsed };
+    }
+  } catch (_) {
+    // Swallow JSON parse errors and fall back to default
+  }
+  return { ...fallback };
+}
+
+function buildRecipientRecord(id, raw) {
+  const data = parseJSON(raw, {});
+  return {
+    id,
+    email: data.email || '',
+    pincode: data.pincode || '201305'
+  };
+}
+
+function buildProductRecord(id, raw) {
+  const data = parseJSON(raw, {});
+  return {
+    id,
+    url: data.url || '',
+    name: data.name || ''
+  };
+}
+
+function buildSubscriptionRecord(id, raw) {
+  const data = parseJSON(raw, {});
+  return {
+    id,
+    recipient_id: data.recipient_id,
+    product_id: data.product_id,
+    start_time: data.start_time || '00:00',
+    end_time: data.end_time || '23:59',
+    paused: !!data.paused
+  };
+}
+
+function serialiseRecipient({ email, pincode }) {
+  return JSON.stringify({ email, pincode: pincode || '201305' });
+}
+
+function serialiseProduct({ url, name }) {
+  return JSON.stringify({ url, name });
+}
+
+function serialiseSubscription({ recipient_id, product_id, start_time, end_time, paused }) {
+  return JSON.stringify({ recipient_id, product_id, start_time, end_time, paused: !!paused });
+}
+
+function serialiseCounters(counters) {
+  const payload = {};
+  for (const [key, value] of Object.entries(counters)) {
+    payload[key] = JSON.stringify(value);
+  }
+  return payload;
+}
+
+function parseCounters(hash) {
+  const counters = {};
+  if (!hash) return counters;
+  for (const [key, value] of Object.entries(hash)) {
+    if (typeof value === 'number') {
+      counters[key] = value;
+      continue;
+    }
+    try {
+      counters[key] = JSON.parse(value);
+    } catch (_) {
+      counters[key] = value;
+    }
+  }
+  return counters;
+}
+
+async function migrateArrayToHash(kvClient, legacyKey, hashKey, serialiser) {
+  if (typeof kvClient.hset !== 'function') return;
+  try {
+    const legacyData = await kvClient.get(legacyKey);
+    if (Array.isArray(legacyData) && legacyData.length > 0) {
+      const entries = Object.fromEntries(
+        legacyData
+          .filter(item => item && item.id)
+          .map(item => [item.id, serialiser(item)])
+      );
+      if (Object.keys(entries).length > 0) {
+        await kvClient.hset(hashKey, entries);
+        if (typeof kvClient.del === 'function') {
+          await kvClient.del(legacyKey);
+        }
+      }
+    }
+  } catch (error) {
+    console.error(`Error migrating ${legacyKey} to hash storage:`, error);
+  }
+}
+
+export async function listRecipients(kvClient = kv) {
+  if (typeof kvClient.hgetall === 'function') {
+    try {
+      const data = await kvClient.hgetall(RECIPIENTS_HASH_KEY);
+      if (data && Object.keys(data).length > 0) {
+        return Object.entries(data)
+          .map(([id, raw]) => buildRecipientRecord(id, raw))
+          .sort((a, b) => a.email.localeCompare(b.email));
+      }
+    } catch (error) {
+      console.error('Error fetching recipients hash from KV:', error);
+    }
+  }
+  await migrateArrayToHash(kvClient, LEGACY_RECIPIENTS_KEY, RECIPIENTS_HASH_KEY, serialiseRecipient);
+  if (typeof kvClient.hgetall === 'function') {
+    const data = await kvClient.hgetall(RECIPIENTS_HASH_KEY);
+    if (data && Object.keys(data).length > 0) {
+      return Object.entries(data)
+        .map(([id, raw]) => buildRecipientRecord(id, raw))
+        .sort((a, b) => a.email.localeCompare(b.email));
+    }
+  }
+  try {
+    const legacy = await kvClient.get(LEGACY_RECIPIENTS_KEY);
+    return Array.isArray(legacy) ? legacy : [];
+  } catch (error) {
+    console.error('Error fetching legacy recipients from KV:', error);
+    return [];
+  }
+}
+
+export async function getRecipient(kvClient = kv, id) {
+  if (!id) return null;
+  if (typeof kvClient.hget === 'function') {
+    try {
+      const raw = await kvClient.hget(RECIPIENTS_HASH_KEY, id);
+      if (raw) return buildRecipientRecord(id, raw);
+    } catch (error) {
+      console.error('Error fetching recipient from hash KV:', error);
+    }
+  }
+  const list = await listRecipients(kvClient);
+  return list.find(item => item.id === id) || null;
+}
+
+export async function saveRecipient(kvClient = kv, recipient) {
+  if (!recipient || !recipient.id) throw new Error('Recipient with id is required');
+  const payload = serialiseRecipient(recipient);
+  if (typeof kvClient.hset === 'function') {
+    await kvClient.hset(RECIPIENTS_HASH_KEY, { [recipient.id]: payload });
+    return;
+  }
+  const existing = await listRecipients(kvClient);
+  const updated = existing.filter(item => item.id !== recipient.id);
+  updated.push(recipient);
+  await kvClient.set(LEGACY_RECIPIENTS_KEY, updated);
+}
+
+export async function deleteRecipient(kvClient = kv, id) {
+  if (!id) return;
+  if (typeof kvClient.hdel === 'function') {
+    await kvClient.hdel(RECIPIENTS_HASH_KEY, id);
+    return;
+  }
+  const existing = await listRecipients(kvClient);
+  const filtered = existing.filter(item => item.id !== id);
+  await kvClient.set(LEGACY_RECIPIENTS_KEY, filtered);
+}
+
+export async function listProducts(kvClient = kv) {
+  if (typeof kvClient.hgetall === 'function') {
+    try {
+      const data = await kvClient.hgetall(PRODUCTS_HASH_KEY);
+      if (data && Object.keys(data).length > 0) {
+        return Object.entries(data)
+          .map(([id, raw]) => buildProductRecord(id, raw))
+          .sort((a, b) => a.name.localeCompare(b.name));
+      }
+    } catch (error) {
+      console.error('Error fetching products hash from KV:', error);
+    }
+  }
+  await migrateArrayToHash(kvClient, LEGACY_PRODUCTS_KEY, PRODUCTS_HASH_KEY, serialiseProduct);
+  if (typeof kvClient.hgetall === 'function') {
+    const data = await kvClient.hgetall(PRODUCTS_HASH_KEY);
+    if (data && Object.keys(data).length > 0) {
+      return Object.entries(data)
+        .map(([id, raw]) => buildProductRecord(id, raw))
+        .sort((a, b) => a.name.localeCompare(b.name));
+    }
+  }
+  try {
+    const legacy = await kvClient.get(LEGACY_PRODUCTS_KEY);
+    return Array.isArray(legacy) ? legacy : [];
+  } catch (error) {
+    console.error('Error fetching legacy products from KV:', error);
+    return [];
+  }
+}
+
+export async function getProduct(kvClient = kv, id) {
+  if (!id) return null;
+  if (typeof kvClient.hget === 'function') {
+    try {
+      const raw = await kvClient.hget(PRODUCTS_HASH_KEY, id);
+      if (raw) return buildProductRecord(id, raw);
+    } catch (error) {
+      console.error('Error fetching product from hash KV:', error);
+    }
+  }
+  const list = await listProducts(kvClient);
+  return list.find(item => item.id === id) || null;
+}
+
+export async function saveProduct(kvClient = kv, product) {
+  if (!product || !product.id) throw new Error('Product with id is required');
+  const payload = serialiseProduct(product);
+  if (typeof kvClient.hset === 'function') {
+    await kvClient.hset(PRODUCTS_HASH_KEY, { [product.id]: payload });
+    return;
+  }
+  const existing = await listProducts(kvClient);
+  const updated = existing.filter(item => item.id !== product.id);
+  updated.push(product);
+  await kvClient.set(LEGACY_PRODUCTS_KEY, updated);
+}
+
+export async function deleteProduct(kvClient = kv, id) {
+  if (!id) return;
+  if (typeof kvClient.hdel === 'function') {
+    await kvClient.hdel(PRODUCTS_HASH_KEY, id);
+    return;
+  }
+  const existing = await listProducts(kvClient);
+  const filtered = existing.filter(item => item.id !== id);
+  await kvClient.set(LEGACY_PRODUCTS_KEY, filtered);
+}
+
+export async function listSubscriptions(kvClient = kv) {
+  if (typeof kvClient.hgetall === 'function') {
+    try {
+      const data = await kvClient.hgetall(SUBSCRIPTIONS_HASH_KEY);
+      if (data && Object.keys(data).length > 0) {
+        return Object.entries(data).map(([id, raw]) => buildSubscriptionRecord(id, raw));
+      }
+    } catch (error) {
+      console.error('Error fetching subscriptions hash from KV:', error);
+    }
+  }
+  await migrateArrayToHash(kvClient, LEGACY_SUBSCRIPTIONS_KEY, SUBSCRIPTIONS_HASH_KEY, serialiseSubscription);
+  if (typeof kvClient.hgetall === 'function') {
+    const data = await kvClient.hgetall(SUBSCRIPTIONS_HASH_KEY);
+    if (data && Object.keys(data).length > 0) {
+      return Object.entries(data).map(([id, raw]) => buildSubscriptionRecord(id, raw));
+    }
+  }
+  try {
+    const legacy = await kvClient.get(LEGACY_SUBSCRIPTIONS_KEY);
+    return Array.isArray(legacy) ? legacy : [];
+  } catch (error) {
+    console.error('Error fetching legacy subscriptions from KV:', error);
+    return [];
+  }
+}
+
+export async function getSubscription(kvClient = kv, id) {
+  if (!id) return null;
+  if (typeof kvClient.hget === 'function') {
+    try {
+      const raw = await kvClient.hget(SUBSCRIPTIONS_HASH_KEY, id);
+      if (raw) return buildSubscriptionRecord(id, raw);
+    } catch (error) {
+      console.error('Error fetching subscription from hash KV:', error);
+    }
+  }
+  const list = await listSubscriptions(kvClient);
+  return list.find(item => item.id === id) || null;
+}
+
+export async function saveSubscription(kvClient = kv, subscription) {
+  if (!subscription || !subscription.id) throw new Error('Subscription with id is required');
+  const payload = serialiseSubscription(subscription);
+  if (typeof kvClient.hset === 'function') {
+    await kvClient.hset(SUBSCRIPTIONS_HASH_KEY, { [subscription.id]: payload });
+    return;
+  }
+  const existing = await listSubscriptions(kvClient);
+  const updated = existing.filter(item => item.id !== subscription.id);
+  updated.push(subscription);
+  await kvClient.set(LEGACY_SUBSCRIPTIONS_KEY, updated);
+}
+
+export async function deleteSubscription(kvClient = kv, id) {
+  if (!id) return;
+  if (typeof kvClient.hdel === 'function') {
+    await kvClient.hdel(SUBSCRIPTIONS_HASH_KEY, id);
+    return;
+  }
+  const existing = await listSubscriptions(kvClient);
+  const filtered = existing.filter(item => item.id !== id);
+  await kvClient.set(LEGACY_SUBSCRIPTIONS_KEY, filtered);
+}
+
+export async function deleteSubscriptionsByIds(kvClient = kv, ids = []) {
+  if (!ids || ids.length === 0) return;
+  if (typeof kvClient.hdel === 'function') {
+    await kvClient.hdel(SUBSCRIPTIONS_HASH_KEY, ...ids);
+    return;
+  }
+  const existing = await listSubscriptions(kvClient);
+  const idSet = new Set(ids);
+  const filtered = existing.filter(item => !idSet.has(item.id));
+  await kvClient.set(LEGACY_SUBSCRIPTIONS_KEY, filtered);
+}
+
+export async function getStockCounters(kvClient = kv) {
+  if (typeof kvClient.hgetall === 'function') {
+    try {
+      const data = await kvClient.hgetall(STOCK_COUNTERS_HASH_KEY);
+      if (data && Object.keys(data).length > 0) {
+        return parseCounters(data);
+      }
+    } catch (error) {
+      console.error('Error fetching stock counters hash from KV:', error);
+    }
+  }
+  try {
+    const legacy = await kvClient.get(LEGACY_STOCK_COUNTERS_KEY);
+    if (legacy && typeof legacy === 'object') {
+      if (typeof kvClient.hset === 'function') {
+        await kvClient.hset(STOCK_COUNTERS_HASH_KEY, serialiseCounters(legacy));
+        if (typeof kvClient.del === 'function') {
+          await kvClient.del(LEGACY_STOCK_COUNTERS_KEY);
+        }
+      }
+      return { ...legacy };
+    }
+  } catch (error) {
+    console.error('Error fetching legacy stock counters from KV:', error);
+  }
+  return {};
+}
+
+export async function saveStockCounters(kvClient = kv, counters) {
+  if (!counters || typeof counters !== 'object') {
+    throw new Error('Counters object is required');
+  }
+  if (typeof kvClient.hset === 'function') {
+    const existing = await kvClient.hgetall?.(STOCK_COUNTERS_HASH_KEY);
+    if (existing && typeof kvClient.hdel === 'function') {
+      const toRemove = Object.keys(existing).filter(key => !(key in counters));
+      if (toRemove.length > 0) {
+        await kvClient.hdel(STOCK_COUNTERS_HASH_KEY, ...toRemove);
+      }
+    }
+    await kvClient.hset(STOCK_COUNTERS_HASH_KEY, serialiseCounters(counters));
+    return;
+  }
+  await kvClient.set(LEGACY_STOCK_COUNTERS_KEY, counters);
+}
+
+export {
+  RECIPIENTS_HASH_KEY,
+  PRODUCTS_HASH_KEY,
+  SUBSCRIPTIONS_HASH_KEY,
+  STOCK_COUNTERS_HASH_KEY
+};

--- a/web/api/_kv-helpers.js
+++ b/web/api/_kv-helpers.js
@@ -112,6 +112,7 @@ async function migrateArrayToHash(kvClient, legacyKey, hashKey, serialiser) {
     }
   } catch (error) {
     console.error(`Error migrating ${legacyKey} to hash storage:`, error);
+    throw error;
   }
 }
 
@@ -126,6 +127,7 @@ export async function listRecipients(kvClient = kv) {
       }
     } catch (error) {
       console.error('Error fetching recipients hash from KV:', error);
+      throw error;
     }
   }
   await migrateArrayToHash(kvClient, LEGACY_RECIPIENTS_KEY, RECIPIENTS_HASH_KEY, serialiseRecipient);
@@ -142,7 +144,7 @@ export async function listRecipients(kvClient = kv) {
     return Array.isArray(legacy) ? legacy : [];
   } catch (error) {
     console.error('Error fetching legacy recipients from KV:', error);
-    return [];
+    throw error;
   }
 }
 
@@ -154,6 +156,7 @@ export async function getRecipient(kvClient = kv, id) {
       if (raw) return buildRecipientRecord(id, raw);
     } catch (error) {
       console.error('Error fetching recipient from hash KV:', error);
+      throw error;
     }
   }
   const list = await listRecipients(kvClient);
@@ -195,6 +198,7 @@ export async function listProducts(kvClient = kv) {
       }
     } catch (error) {
       console.error('Error fetching products hash from KV:', error);
+      throw error;
     }
   }
   await migrateArrayToHash(kvClient, LEGACY_PRODUCTS_KEY, PRODUCTS_HASH_KEY, serialiseProduct);
@@ -211,7 +215,7 @@ export async function listProducts(kvClient = kv) {
     return Array.isArray(legacy) ? legacy : [];
   } catch (error) {
     console.error('Error fetching legacy products from KV:', error);
-    return [];
+    throw error;
   }
 }
 
@@ -223,6 +227,7 @@ export async function getProduct(kvClient = kv, id) {
       if (raw) return buildProductRecord(id, raw);
     } catch (error) {
       console.error('Error fetching product from hash KV:', error);
+      throw error;
     }
   }
   const list = await listProducts(kvClient);
@@ -262,6 +267,7 @@ export async function listSubscriptions(kvClient = kv) {
       }
     } catch (error) {
       console.error('Error fetching subscriptions hash from KV:', error);
+      throw error;
     }
   }
   await migrateArrayToHash(kvClient, LEGACY_SUBSCRIPTIONS_KEY, SUBSCRIPTIONS_HASH_KEY, serialiseSubscription);
@@ -276,7 +282,7 @@ export async function listSubscriptions(kvClient = kv) {
     return Array.isArray(legacy) ? legacy : [];
   } catch (error) {
     console.error('Error fetching legacy subscriptions from KV:', error);
-    return [];
+    throw error;
   }
 }
 
@@ -288,6 +294,7 @@ export async function getSubscription(kvClient = kv, id) {
       if (raw) return buildSubscriptionRecord(id, raw);
     } catch (error) {
       console.error('Error fetching subscription from hash KV:', error);
+      throw error;
     }
   }
   const list = await listSubscriptions(kvClient);
@@ -339,6 +346,7 @@ export async function getStockCounters(kvClient = kv) {
       }
     } catch (error) {
       console.error('Error fetching stock counters hash from KV:', error);
+      throw error;
     }
   }
   try {
@@ -354,6 +362,7 @@ export async function getStockCounters(kvClient = kv) {
     }
   } catch (error) {
     console.error('Error fetching legacy stock counters from KV:', error);
+    throw error;
   }
   return {};
 }

--- a/web/api/configuration.js
+++ b/web/api/configuration.js
@@ -1,0 +1,44 @@
+import { kv } from '@vercel/kv';
+import {
+  listRecipients,
+  listProducts,
+  listSubscriptions,
+  getStockCounters
+} from './_kv-helpers.js';
+
+let kvClient = kv;
+
+export function __setKv(mock) {
+  kvClient = mock;
+}
+
+export function __resetKv() {
+  kvClient = kv;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    res.status(405).json({ message: `Method ${req.method} Not Allowed` });
+    return;
+  }
+
+  try {
+    const [recipients, products, subscriptions, counters] = await Promise.all([
+      listRecipients(kvClient),
+      listProducts(kvClient),
+      listSubscriptions(kvClient),
+      getStockCounters(kvClient)
+    ]);
+
+    res.status(200).json({
+      recipients,
+      products,
+      subscriptions,
+      stock_counters: counters || {}
+    });
+  } catch (error) {
+    console.error('Error building configuration payload:', error);
+    res.status(500).json({ message: 'Error loading configuration', error: error.message });
+  }
+}

--- a/web/api/email-blast.js
+++ b/web/api/email-blast.js
@@ -1,11 +1,13 @@
-import { kv } from '@vercel/kv';
-import { requireAdmin } from '../utils/auth.js'; 
+import { requireAdmin } from '../utils/auth.js';
 import nodemailer from 'nodemailer';
+import {
+  listRecipients as listRecipientsFromKV,
+  listSubscriptions as listSubscriptionsFromKV
+} from './_kv-helpers.js';
 
 async function getRecipientsFromKV() {
   try {
-    const recipientsData = await kv.get('recipients');
-    return recipientsData || [];
+    return await listRecipientsFromKV();
   } catch (error) {
     console.error('Error fetching recipients from KV:', error);
     return [];
@@ -14,8 +16,7 @@ async function getRecipientsFromKV() {
 
 async function getSubscriptionsFromKV() {
   try {
-    const subscriptionsData = await kv.get('subscriptions');
-    return subscriptionsData || [];
+    return await listSubscriptionsFromKV();
   } catch (error) {
     console.error('Error fetching subscriptions from KV:', error);
     return [];

--- a/web/api/github.js
+++ b/web/api/github.js
@@ -38,11 +38,17 @@ function applyCacheHeaders(res, ttl = CACHE_TTL_SECONDS) {
 }
 
 function isKvUsable() {
-  if (!kvClient || typeof kvClient.get !== 'function' || typeof kvClient.set !== 'function') {
+  if (!kvClient) {
     return false;
   }
-  if (kvClient === kv) {
-    return Boolean(process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN);
+  const usingDefaultClient = kvClient === kv;
+  if (usingDefaultClient && !(process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN)) {
+    return false;
+  }
+  const getFn = kvClient.get;
+  const setFn = kvClient.set;
+  if (typeof getFn !== 'function' || typeof setFn !== 'function') {
+    return false;
   }
   return true;
 }

--- a/web/api/products.js
+++ b/web/api/products.js
@@ -1,5 +1,12 @@
 import { kv } from '@vercel/kv';
 import { requireAdmin as defaultRequireAdmin } from '../utils/auth.js';
+import {
+  listProducts as listProductsFromKV,
+  saveProduct as saveProductToKV,
+  deleteProduct as deleteProductFromKV,
+  listSubscriptions as listSubscriptionsFromKV,
+  deleteSubscriptionsByIds
+} from './_kv-helpers.js';
 
 let kvClient = kv;
 let requireAdmin = defaultRequireAdmin;
@@ -20,53 +27,10 @@ export function __resetRequireAdmin() {
   requireAdmin = defaultRequireAdmin;
 }
 
-// KV Helper functions for Products
-async function getProductsFromKV() {
-  try {
-    const productsData = await kvClient.get('products');
-    if (productsData) {
-      productsData.sort((a, b) => a.name.localeCompare(b.name));
-    }
-    return productsData ? productsData : [];
-  } catch (error) {
-    console.error('Error fetching products from KV:', error);
-    throw error;
-  }
-}
-
-async function saveProductsToKV(productsArray) {
-  try {
-    await kvClient.set('products', productsArray);
-  } catch (error) {
-    console.error('Error saving products to KV:', error);
-    throw new Error('Could not save products to KV.');
-  }
-}
-
-// KV Helper functions for Subscriptions (needed for cascading delete)
-async function getSubscriptionsFromKV() {
-  try {
-    const subscriptionsData = await kvClient.get('subscriptions');
-    return subscriptionsData ? subscriptionsData : [];
-  } catch (error) {
-    console.error('Error fetching subscriptions from KV:', error);
-    throw error;
-  }
-}
-
-async function saveSubscriptionsToKV(subscriptionsArray) {
-  try {
-    await kvClient.set('subscriptions', subscriptionsArray);
-  } catch (error) {
-    console.error('Error saving subscriptions to KV:', error);
-    throw new Error('Could not save subscriptions to KV.');
-  }
-}
-
 // Main request handler
 async function handleGet(req, res) {
   try {
-    const products = await getProductsFromKV();
+    const products = await listProductsFromKV(kvClient);
     res.status(200).json(products);
   } catch (error) {
     console.error("Error in GET /api/products:", error);
@@ -94,7 +58,7 @@ async function handlePost(req, res) {
       return res.status(400).json({ message: 'Invalid product name' });
     }
 
-    const currentProducts = await getProductsFromKV();
+    const currentProducts = await listProductsFromKV(kvClient);
     if (currentProducts.find(p => p.url === url)) {
       return res.status(409).json({ message: 'Product with this URL already exists' });
     }
@@ -105,8 +69,7 @@ async function handlePost(req, res) {
       name: name.trim()
     };
 
-    currentProducts.push(newProduct);
-    await saveProductsToKV(currentProducts);
+    await saveProductToKV(kvClient, newProduct);
     res.status(201).json(newProduct);
   } catch (error) {
     console.error("Error in POST /api/products:", error);
@@ -138,18 +101,18 @@ async function handlePut(req, res) {
       return res.status(400).json({ message: 'Invalid product name' });
     }
 
-    let currentProducts = await getProductsFromKV();
+    const currentProducts = await listProductsFromKV(kvClient);
     const productIndex = currentProducts.findIndex(p => p.id === id);
     if (productIndex === -1) {
       return res.status(404).json({ message: 'Product not found' });
     }
-    currentProducts[productIndex] = {
+    const updated = {
       ...currentProducts[productIndex],
       url,
       name: name.trim()
     };
-    await saveProductsToKV(currentProducts);
-    res.status(200).json(currentProducts[productIndex]);
+    await saveProductToKV(kvClient, updated);
+    res.status(200).json(updated);
   } catch (error) {
     console.error('Error in PUT /api/products:', error);
     res.status(500).json({ message: 'Error updating product in KV', error: error.message });
@@ -165,21 +128,22 @@ async function handleDelete(req, res) {
       return res.status(400).json({ message: 'Product ID is required' });
     }
 
-    let currentProducts = await getProductsFromKV();
+    const currentProducts = await listProductsFromKV(kvClient);
     const productIndex = currentProducts.findIndex(p => p.id === productIdToDelete);
 
     if (productIndex === -1) {
       return res.status(404).json({ message: 'Product not found' });
     }
 
-    const updatedProducts = currentProducts.filter(p => p.id !== productIdToDelete);
-    await saveProductsToKV(updatedProducts);
+    await deleteProductFromKV(kvClient, productIdToDelete);
 
-    let currentSubscriptions = await getSubscriptionsFromKV();
-    const updatedSubscriptions = currentSubscriptions.filter(s => s.product_id !== productIdToDelete);
+    const currentSubscriptions = await listSubscriptionsFromKV(kvClient);
+    const subsToDelete = currentSubscriptions
+      .filter(s => s.product_id === productIdToDelete)
+      .map(s => s.id);
 
-    if (updatedSubscriptions.length < currentSubscriptions.length) {
-      await saveSubscriptionsToKV(updatedSubscriptions);
+    if (subsToDelete.length > 0) {
+      await deleteSubscriptionsByIds(kvClient, subsToDelete);
     }
 
     res.status(200).json({ message: 'Product and associated subscriptions deleted successfully' });

--- a/web/api/recipients.js
+++ b/web/api/recipients.js
@@ -1,5 +1,12 @@
 import { kv } from '@vercel/kv';
 import { requireAdmin as defaultRequireAdmin } from '../utils/auth.js';
+import {
+  listRecipients as listRecipientsFromKV,
+  saveRecipient as saveRecipientToKV,
+  deleteRecipient as deleteRecipientFromKV,
+  listSubscriptions as listSubscriptionsFromKV,
+  deleteSubscriptionsByIds
+} from './_kv-helpers.js';
 
 let kvClient = kv;
 let requireAdmin = defaultRequireAdmin;
@@ -20,46 +27,6 @@ export function __resetRequireAdmin() {
   requireAdmin = defaultRequireAdmin;
 }
 
-// KV Helper functions for Recipients
-async function getRecipientsFromKV() {
-  try {
-    const recipientsData = await kvClient.get('recipients');
-    return recipientsData ? recipientsData : []; // KV returns the object directly if stored as such
-  } catch (error) {
-    console.error('Error fetching recipients from KV:', error);
-    throw error;
-  }
-}
-
-async function saveRecipientsToKV(recipientsArray) {
-  try {
-    await kvClient.set('recipients', recipientsArray);
-  } catch (error) {
-    console.error('Error saving recipients to KV:', error);
-    throw new Error('Could not save recipients to KV.');
-  }
-}
-
-// KV Helper functions for Subscriptions (needed for cascading delete)
-async function getSubscriptionsFromKV() {
-  try {
-    const subscriptionsData = await kvClient.get('subscriptions');
-    return subscriptionsData ? subscriptionsData : [];
-  } catch (error) {
-    console.error('Error fetching subscriptions from KV:', error);
-    throw error;
-  }
-}
-
-async function saveSubscriptionsToKV(subscriptionsArray) {
-  try {
-    await kvClient.set('subscriptions', subscriptionsArray);
-  } catch (error) {
-    console.error('Error saving subscriptions to KV:', error);
-    throw new Error('Could not save subscriptions to KV.');
-  }
-}
-
 function normalizeEmail(email) {
   if (typeof email !== 'string') return '';
   return email.trim().toLowerCase();
@@ -72,7 +39,7 @@ export default async function handler(req, res) {
   switch (method) {
     case 'GET':
       try {
-        const recipients = await getRecipientsFromKV();
+        const recipients = await listRecipientsFromKV(kvClient);
         res.status(200).json(recipients);
       } catch (error) {
         console.error("Error in GET /api/recipients:", error);
@@ -91,7 +58,7 @@ export default async function handler(req, res) {
           return res.status(400).json({ message: 'Invalid email address' });
         }
 
-        const currentRecipients = await getRecipientsFromKV();
+        const currentRecipients = await listRecipientsFromKV(kvClient);
         if (currentRecipients.some(r => normalizeEmail(r.email) === normalizedEmail)) {
           return res.status(409).json({ message: 'Email already exists' });
         }
@@ -102,8 +69,7 @@ export default async function handler(req, res) {
           pincode: typeof pincode === 'string' && pincode.trim() ? pincode.trim() : '201305'
         };
 
-        currentRecipients.push(newRecipient);
-        await saveRecipientsToKV(currentRecipients);
+        await saveRecipientToKV(kvClient, newRecipient);
         res.status(201).json(newRecipient);
       } catch (error) {
         console.error("Error in POST /api/recipients:", error);
@@ -121,14 +87,14 @@ export default async function handler(req, res) {
         if (!pincode || typeof pincode !== 'string') {
           return res.status(400).json({ message: 'Invalid pincode' });
         }
-        const recips = await getRecipientsFromKV();
+        const recips = await listRecipientsFromKV(kvClient);
         const idx = recips.findIndex(r => r.id === id);
         if (idx === -1) {
           return res.status(404).json({ message: 'Recipient not found' });
         }
-        recips[idx] = { ...recips[idx], pincode: pincode.trim() };
-        await saveRecipientsToKV(recips);
-        res.status(200).json(recips[idx]);
+        const updated = { ...recips[idx], pincode: pincode.trim() };
+        await saveRecipientToKV(kvClient, updated);
+        res.status(200).json(updated);
       } catch (error) {
         console.error('Error in PUT /api/recipients:', error);
         res.status(500).json({ message: 'Error updating recipient in KV', error: error.message });
@@ -144,24 +110,22 @@ export default async function handler(req, res) {
           return res.status(400).json({ message: 'Recipient ID is required' });
         }
 
-        let currentRecipients = await getRecipientsFromKV();
+        const currentRecipients = await listRecipientsFromKV(kvClient);
         const recipientIndex = currentRecipients.findIndex(r => r.id === recipientIdToDelete);
 
         if (recipientIndex === -1) {
           return res.status(404).json({ message: 'Recipient not found' });
         }
 
-        // Filter out the recipient
-        const updatedRecipients = currentRecipients.filter(r => r.id !== recipientIdToDelete);
-        await saveRecipientsToKV(updatedRecipients);
+        // Remove the recipient record and cascade delete subscriptions
+        await deleteRecipientFromKV(kvClient, recipientIdToDelete);
 
-        // Remove associated subscriptions
-        let currentSubscriptions = await getSubscriptionsFromKV();
-        const updatedSubscriptions = currentSubscriptions.filter(s => s.recipient_id !== recipientIdToDelete);
-
-        // Save subscriptions only if they changed
-        if (updatedSubscriptions.length < currentSubscriptions.length) {
-            await saveSubscriptionsToKV(updatedSubscriptions);
+        const subscriptions = await listSubscriptionsFromKV(kvClient);
+        const subsToDelete = subscriptions
+          .filter(s => s.recipient_id === recipientIdToDelete)
+          .map(s => s.id);
+        if (subsToDelete.length > 0) {
+          await deleteSubscriptionsByIds(kvClient, subsToDelete);
         }
 
         res.status(200).json({ message: 'Recipient and associated subscriptions deleted successfully' });

--- a/web/api/stock-counters.js
+++ b/web/api/stock-counters.js
@@ -1,9 +1,20 @@
 import { kv } from '@vercel/kv';
 import { requireAdmin } from '../utils/auth.js';
+import { getStockCounters, saveStockCounters } from './_kv-helpers.js';
+
+let kvClient = kv;
+
+export function __setKv(mock) {
+  kvClient = mock;
+}
+
+export function __resetKv() {
+  kvClient = kv;
+}
 
 async function handleGet(req, res) {
   try {
-    const data = await kv.get('stock_counters');
+    const data = await getStockCounters(kvClient);
     res.status(200).json(data || {});
   } catch (err) {
     console.error('Error fetching stock counters from KV:', err);
@@ -18,7 +29,7 @@ async function handlePut(req, res) {
     if (!counters || typeof counters !== 'object') {
       return res.status(400).json({ message: 'Invalid counters data' });
     }
-    await kv.set('stock_counters', counters);
+    await saveStockCounters(kvClient, counters);
     res.status(200).json({ message: 'Counters updated' });
   } catch (err) {
     console.error('Error saving stock counters to KV:', err);

--- a/web/components/runs/runs.js
+++ b/web/components/runs/runs.js
@@ -18,7 +18,13 @@ async function fetchLogArchiveBuffer(runId) {
       if (!resp.ok) {
         throw new Error(`Failed to fetch logs: ${resp.status}`);
       }
-      return resp.arrayBuffer();
+      if (typeof resp.arrayBuffer === 'function') {
+        return resp.arrayBuffer();
+      }
+      if (typeof resp.blob === 'function') {
+        return resp.blob();
+      }
+      throw new Error('Response does not support arrayBuffer or blob');
     })
     .then(buffer => {
       logArchiveCache.set(runId, buffer);

--- a/web/node_modules/@vercel/kv/index.js
+++ b/web/node_modules/@vercel/kv/index.js
@@ -1,1 +1,67 @@
-export const kv = { get: async () => null, set: async () => {}, del: async () => {} };
+const valueStore = new Map();
+const hashStore = new Map();
+
+function isExpired(entry) {
+  if (!entry) return true;
+  if (!entry.expiresAt) return false;
+  return Date.now() > entry.expiresAt;
+}
+
+export const kv = {
+  async get(key) {
+    const entry = valueStore.get(key);
+    if (!entry || isExpired(entry)) {
+      if (entry && isExpired(entry)) {
+        valueStore.delete(key);
+      }
+      return null;
+    }
+    return entry.value;
+  },
+  async set(key, value, options = {}) {
+    const expiresAt = options.ex ? Date.now() + options.ex * 1000 : null;
+    valueStore.set(key, { value, expiresAt });
+  },
+  async del(key) {
+    valueStore.delete(key);
+    hashStore.delete(key);
+  },
+  async hgetall(key) {
+    const hash = hashStore.get(key);
+    if (!hash || hash.size === 0) return null;
+    const result = {};
+    for (const [field, value] of hash.entries()) {
+      result[field] = value;
+    }
+    return result;
+  },
+  async hset(key, values) {
+    let hash = hashStore.get(key);
+    if (!hash) {
+      hash = new Map();
+      hashStore.set(key, hash);
+    }
+    for (const [field, value] of Object.entries(values || {})) {
+      hash.set(field, value);
+    }
+  },
+  async hget(key, field) {
+    const hash = hashStore.get(key);
+    if (!hash) return null;
+    return hash.get(field) ?? null;
+  },
+  async hdel(key, ...fields) {
+    const hash = hashStore.get(key);
+    if (!hash) return 0;
+    let removed = 0;
+    for (const field of fields) {
+      if (hash.delete(field)) {
+        removed += 1;
+      }
+    }
+    if (hash.size === 0) {
+      hashStore.delete(key);
+    }
+    return removed;
+  }
+};


### PR DESCRIPTION
## Summary
- add a shared KV helper that stores recipients, products, subscriptions, and counters in hash buckets and update the API routes to use incremental writes
- expose a new /api/configuration endpoint and teach the stock checker workflow to pull the bundle instead of hitting many endpoints
- cache GitHub workflow metadata and log archives in KV and let the dashboard reuse a single log download when rendering overviews and tabs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3cf03d2c4832f966395b988c97c74