### PR TITLE
Fix requirements dependency ordering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,9 @@ idna==3.10
 multidict==6.6.3
 propcache==0.3.2
 pyee==11.0.1
+pytest-asyncio==1.1.0
 six==1.17.0
 soupsieve==2.7
 typing-extensions==4.14.1
 urllib3==2.5.0
 yarl==1.20.1
-pytest-asyncio==1.1.0


### PR DESCRIPTION
## Summary
- resolve the merge conflict in requirements.txt by ordering pytest-asyncio with other transitive dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3db8def54832fba108843b32bd0a2