### PR TITLE
Fix pyee version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ greenlet==3.1.1
 idna==3.10
 multidict==6.6.4
 propcache==0.3.2
-pyee==11.0.1
+pyee==13.0.0
 six==1.17.0
 soupsieve==2.7
 typing-extensions==4.14.1


### PR DESCRIPTION
## Summary
- update the pinned pyee dependency to a version compatible with Playwright 1.54.0
- ensure the requirements file is properly newline-terminated

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ddfd46f8832f99d9c2933afca12a