### PR TITLE
Fix user login recipient lookup

### DIFF
--- a/web/api/login.js
+++ b/web/api/login.js
@@ -1,6 +1,7 @@
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { kv as defaultKv } from '@vercel/kv';
+import { listRecipients as listRecipientsFromKV } from './_kv-helpers.js';
 
 let kv = defaultKv;
 export function __setKv(obj) {
@@ -94,7 +95,7 @@ export default async function handler(req, res) {
   }
 
   try {
-    const recipients = await kv.get('recipients');
+    const recipients = await listRecipientsFromKV(kv);
     const exists =
       Array.isArray(recipients) &&
       recipients.some(r => typeof r.email === 'string' && r.email.trim().toLowerCase() === normalizedEmail);


### PR DESCRIPTION
## Summary
- update the login API to retrieve recipients via the shared KV helper so hashed storage works for user accounts
- expand the login API unit tests to support custom KV mocks and cover the hashed recipients scenario

## Testing
- node --test test/api-login.test.js


------
https://chatgpt.com/codex/tasks/task_e_68d936c93a78832f85dfdefeb8efdd7e